### PR TITLE
Configure CI and tweak README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Rust
+      run: |
+        rustup update stable
+        rustup default stable
+        rustup component add rustfmt
+    - name: Cargo fmt
+      run: cargo fmt --all -- --check
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macOS]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Rust
+      shell: bash
+      run: |
+        rustup update stable
+        rustup default stable
+    - name: Build
+      run: cargo build --all --release -vv
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macOS]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install Rust
+      shell: bash
+      run: |
+        rustup update stable
+        rustup default stable
+    - name: Test
+      run: cargo test --all
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
-This crate provides a capability-based version of [`std`]. It provides all the
+<div align="center">
+  <h1><code>cap-std</code></h1>
+
+  <p>
+    <strong>Capability-based version of Rust standard library</strong>
+  </p>
+
+  <p>
+    <a href="https://github.com/sunfishcode/cap-std/actions?query=workflow%3ACI"><img src="https://github.com/sunfishcode/cap-std/workflows/CI/badge.svg" alt="build status" /></a>
+  </p>
+</div>
+
+`cap-std` crate provides a capability-based version of [`std`]. It provides all the
 interfaces you are used to, but in a capability-based version.
 
 [`std`]: https://doc.rust-lang.org/std/index.html
 
-It is a work in progress and many things aren't implemented yet.
+**It is a work in progress and many things aren't implemented yet.**
+
+## The story
 
 The two most interesting features are `fs::Dir` and `net::Catalog` (name TBD).
 Dirs represent capabilities for accessing files beneath them, and "catalogs"


### PR DESCRIPTION
CI conf explained -- we've got three jobs types: `rustfmt`, `build` and `test`. `rustfmt` is run only on Linux, `build` and `test` are both run on Linux and macOS (Windows and WASI support will land after we figure the basics and tests for those targets). `build` builds the project in *release* mode, while `test` runs `cargo test --all` in *debug* mode.

While here, I've also tweaked the README.md to feature a banner plus a CI status badge.