### PR TITLE
Add Dir::is_dir and refactor Dir::create_dir_all

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -103,13 +103,9 @@ impl Dir {
 
         match self.create_dir(path) {
             Ok(()) => return Ok(()),
-            Err(e) => match e.kind() {
-                io::ErrorKind::NotFound => {}
-                io::ErrorKind::AlreadyExists => {
-                    return if self.is_dir(path) { Ok(()) } else { Err(e) }
-                }
-                _ => return Err(e),
-            },
+            Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(_) if self.is_dir(path) => return Ok(()),
+            Err(e) => return Err(e),
         }
         match path.parent() {
             Some(p) => self._create_dir_all(p)?,
@@ -122,16 +118,8 @@ impl Dir {
         }
         match self.create_dir(path) {
             Ok(()) => Ok(()),
-            Err(e) => match e.kind() {
-                io::ErrorKind::AlreadyExists => {
-                    if self.is_dir(path) {
-                        Ok(())
-                    } else {
-                        Err(e)
-                    }
-                }
-                _ => Err(e),
-            },
+            Err(_) if self.is_dir(path) => Ok(()),
+            Err(e) => Err(e),
         }
     }
 
@@ -442,7 +430,7 @@ impl Dir {
     /// [`std::path::Path::is_dir`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_dir
     #[inline]
     pub fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
-        unimplemented!("TODO implement is_dir")
+        self.open_dir(path.as_ref()).map(|_| true).unwrap_or(false)
     }
 }
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -31,47 +31,6 @@ use cap_std::os::windows::fs::{symlink_dir, symlink_file};
 use cap_std::sys::fs::symlink_junction;
 */
 
-macro_rules! check {
-    ($e:expr) => {
-        match $e {
-            Ok(t) => t,
-            Err(e) => panic!("{} failed with: {}", stringify!($e), e),
-        }
-    };
-}
-
-#[cfg(windows)]
-macro_rules! error {
-    ($e:expr, $s:expr) => {
-        match $e {
-            Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(
-                err.raw_os_error() == Some($s),
-                format!("`{}` did not have a code of `{}`", err, $s)
-            ),
-        }
-    };
-}
-
-#[cfg(unix)]
-macro_rules! error {
-    ($e:expr, $s:expr) => {
-        error_contains!($e, $s)
-    };
-}
-
-macro_rules! error_contains {
-    ($e:expr, $s:expr) => {
-        match $e {
-            Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(
-                err.to_string().contains($s),
-                format!("`{}` did not contain `{}`", err, $s)
-            ),
-        }
-    };
-}
-
 /*
 // Several test fail on windows if the user does not have permission to
 // create symlinks (the `SeCreateSymbolicLinkPrivilege`). Instead of
@@ -540,10 +499,7 @@ fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
     check!(tmpdir.create_dir_all(dir));
-    assert!(tmpdir.is_dir("d1"));
-    let dir = check!(tmpdir.open_dir("d1"));
-    assert!(dir.is_dir("d2"));
-    assert!(tmpdir.is_dir("d1/d2"));
+    assert!(tmpdir.is_dir(dir));
 }
 
 #[test]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -535,18 +535,18 @@ fn mkdir_path_already_exists_error() {
     assert_eq!(e.kind(), ErrorKind::AlreadyExists);
 }
 
-/*
 #[test]
 fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
     check!(tmpdir.create_dir_all(dir));
-    assert!(dir.is_dir())
+    assert!(tmpdir.is_dir("d1"));
+    let dir = check!(tmpdir.open_dir("d1"));
+    assert!(dir.is_dir("d2"));
+    assert!(tmpdir.is_dir("d1/d2"));
 }
-*/
 
 #[test]
-#[ignore] // create_dir_all is not yet implemented in cap-std
 fn recursive_mkdir_failure() {
     let tmpdir = tmpdir();
     let dir = "d1";
@@ -585,21 +585,18 @@ fn concurrent_recursive_mkdir() {
 */
 
 #[test]
-#[ignore] // create_dir_all is not yet implemented in cap-std
 fn recursive_mkdir_slash() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all(Path::new("/")));
 }
 
 #[test]
-#[ignore] // create_dir_all is not yet implemented in cap-std
 fn recursive_mkdir_dot() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all(Path::new(".")));
 }
 
 #[test]
-#[ignore] // create_dir_all is not yet implemented in cap-std
 fn recursive_mkdir_empty() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all(Path::new("")));

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -1,0 +1,18 @@
+// This file contains additional fs tests that didn't make it into `fs.rs`.
+// The reason for additional module to contain those is so that `fs.rs` mirrors
+// Rust's libstd tests.
+
+mod sys_common;
+
+use sys_common::io::tmpdir;
+
+#[test]
+fn recursive_mkdir() {
+    let tmpdir = tmpdir();
+    let dir = "d1/d2";
+    check!(tmpdir.create_dir_all(dir));
+    assert!(tmpdir.is_dir("d1"));
+    let dir = check!(tmpdir.open_dir("d1"));
+    assert!(dir.is_dir("d2"));
+    assert!(tmpdir.is_dir("d1/d2"));
+}

--- a/tests/sys_common/mod.rs
+++ b/tests/sys_common/mod.rs
@@ -1,1 +1,45 @@
+#![macro_use]
 pub mod io;
+
+macro_rules! check {
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(e) => panic!("{} failed with: {}", stringify!($e), e),
+        }
+    };
+}
+
+#[cfg(windows)]
+macro_rules! error {
+    ($e:expr, $s:expr) => {
+        match $e {
+            Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
+            Err(ref err) => assert!(
+                err.raw_os_error() == Some($s),
+                format!("`{}` did not have a code of `{}`", err, $s)
+            ),
+        }
+    };
+}
+
+#[cfg(unix)]
+#[allow(unused)]
+macro_rules! error {
+    ($e:expr, $s:expr) => {
+        error_contains!($e, $s)
+    };
+}
+
+#[allow(unused)]
+macro_rules! error_contains {
+    ($e:expr, $s:expr) => {
+        match $e {
+            Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
+            Err(ref err) => assert!(
+                err.to_string().contains($s),
+                format!("`{}` did not contain `{}`", err, $s)
+            ),
+        }
+    };
+}


### PR DESCRIPTION
This commit adds `Dir::is_dir` and refactors `Dir::create_dir_all`
which makes use of it internally. This commit also enables several
tests testing `create_dir_all` along both positive and negative
execution paths.