### PR TITLE
Implement Rust-compatible `OpenOptions` translation.

### DIFF
--- a/cap-primitives/src/std/fs/open.rs
+++ b/cap-primitives/src/std/fs/open.rs
@@ -29,10 +29,10 @@ pub fn open(start: &fs::File, path: &Path, options: &OpenOptions) -> io::Result<
             Ok(result_file) => {
                 assert!(is_same_file(result_file, &unchecked_file)?,
                     "path resolution inconsistency: start='{:?}', path='{}' got='{:?}' expected='{:?}'",
-                    get_path(start), path.display(), get_path(&result.unwrap()), get_path(&unchecked_file));
+                    get_path(start), path.display(), get_path(result_file), get_path(&unchecked_file));
             }
             Err(e) => match e.kind() {
-                io::ErrorKind::PermissionDenied => (),
+                io::ErrorKind::PermissionDenied | io::ErrorKind::InvalidInput => (),
                 io::ErrorKind::AlreadyExists if options.create_new => (),
                 _ => panic!(
                     "unexpected error opening start='{:?}', path='{}': {:?}",
@@ -51,7 +51,7 @@ pub fn open(start: &fs::File, path: &Path, options: &OpenOptions) -> io::Result<
                 result_file
             ),
             Err(result_error) => match result_error.kind() {
-                io::ErrorKind::PermissionDenied => (),
+                io::ErrorKind::PermissionDenied | io::ErrorKind::InvalidInput => (),
                 _ => {
                     assert_eq!(result_error.to_string(), unchecked_error.to_string());
                     assert_eq!(result_error.kind(), unchecked_error.kind());

--- a/cap-primitives/src/yanix/common/fs/flags.rs
+++ b/cap-primitives/src/yanix/common/fs/flags.rs
@@ -1,33 +1,53 @@
 use crate::fs::OpenOptions;
 use yanix::file::OFlag;
+use std::io;
 
-pub(crate) fn compute_oflags(options: &OpenOptions) -> OFlag {
-    // TODO: Diagnose invalid combinations.
+pub(crate) fn compute_oflags(options: &OpenOptions) -> io::Result<OFlag> {
+    // TODO: Add `CLOEXEC` when yanix is updated.
     let mut oflags = OFlag::empty();
-    if options.read && options.write {
-        oflags |= OFlag::RDWR;
-    } else if options.read {
-        oflags |= OFlag::RDONLY;
-    } else if options.write {
-        oflags |= OFlag::WRONLY;
-    }
-    if options.append {
-        oflags |= OFlag::APPEND;
-    }
-    if options.create_new {
-        oflags |= OFlag::EXCL | OFlag::CREAT;
-    } else {
-        if options.truncate {
-            oflags |= OFlag::TRUNC;
-        }
-        if options.create {
-            oflags |= OFlag::CREAT;
-        }
-    }
+    oflags |= OFlag::from_bits(get_access_mode(options)?).unwrap();
+    oflags |= OFlag::from_bits(get_creation_mode(options)?).unwrap();
     if options.nofollow {
         oflags |= OFlag::NOFOLLOW;
     }
     oflags |= OFlag::from_bits(options.ext.custom_flags).expect("unrecognized OFlag bits")
         & !OFlag::ACCMODE;
-    oflags
+    Ok(oflags)
+}
+
+// `OpenOptions` translation code derived from Rust's src/libstd/sys/unix/fs.rs
+
+fn get_access_mode(options: &OpenOptions) -> io::Result<libc::c_int> {
+    match (options.read, options.write, options.append) {
+        (true, false, false) => Ok(libc::O_RDONLY),
+        (false, true, false) => Ok(libc::O_WRONLY),
+        (true, true, false) => Ok(libc::O_RDWR),
+        (false, _, true) => Ok(libc::O_WRONLY | libc::O_APPEND),
+        (true, _, true) => Ok(libc::O_RDWR | libc::O_APPEND),
+        (false, false, false) => Err(io::Error::from_raw_os_error(libc::EINVAL)),
+    }
+}
+
+fn get_creation_mode(options: &OpenOptions) -> io::Result<libc::c_int> {
+    match (options.write, options.append) {
+        (true, false) => {}
+        (false, false) => {
+            if options.truncate || options.create || options.create_new {
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+            }
+        }
+        (_, true) => {
+            if options.truncate && !options.create_new {
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+            }
+        }
+    }
+
+    Ok(match (options.create, options.truncate, options.create_new) {
+        (false, false, false) => 0,
+        (true, false, false) => libc::O_CREAT,
+        (false, true, false) => libc::O_TRUNC,
+        (true, true, false) => libc::O_CREAT | libc::O_TRUNC,
+        (_, _, true) => libc::O_CREAT | libc::O_EXCL,
+    })
 }

--- a/cap-primitives/src/yanix/common/fs/open_unchecked.rs
+++ b/cap-primitives/src/yanix/common/fs/open_unchecked.rs
@@ -15,7 +15,7 @@ pub(crate) fn open_unchecked(
     path: &Path,
     options: &OpenOptions,
 ) -> io::Result<fs::File> {
-    let oflags = compute_oflags(options);
+    let oflags = compute_oflags(options)?;
 
     #[allow(clippy::useless_conversion)]
     let mode = Mode::from_bits_truncate(options.ext.mode as _);

--- a/cap-primitives/src/yanix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/open_impl.rs
@@ -44,7 +44,7 @@ pub(crate) fn open_impl(
 ) -> io::Result<fs::File> {
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(Relaxed) {
-        let oflags = compute_oflags(options);
+        let oflags = compute_oflags(options)?;
 
         // TODO use `yanix::file::OFlags` when `TMPFILE` is introduced
         // Until then, since `O_TMPFILE := 0x20000000 | libc::O_DIRECTORY`,

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1008,7 +1008,6 @@ fn truncate_works() {
 }
 
 #[test]
-#[ignore] // cap-std's OpenOptions doesn't handle all the flags correctly yet
 fn open_flavors() {
     use cap_std::fs::OpenOptions as OO;
     fn c<T: Clone>(t: &T) -> T {


### PR DESCRIPTION
The `open_flavors` test now passes!