### PR TITLE
Remove some TODO comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Things to think about:
    `read_link`, `read_dir`, `symlink_metadata`, `canonicalize`. Is it
    worth having our own version of `Path` just to exclude those? Such a
    thing could also exclude absolute paths.
- - Should we provide any of Rust's Unix-specific APIs on Windows, using
-   winx and emulation?
  - Should we propose adding things to Rust's libstd which would help streamline this library?
     - A way to construct an arbitrary [`std::fs::FileType`] and [`std::fs::Metadata`]?
     - A way to read the options out of a [`std::fs::OpenOptions`] and [`std::fs::DirBuilder`]?

--- a/cap-async-std/README.md
+++ b/cap-async-std/README.md
@@ -41,8 +41,6 @@ Things to think about:
    `read_link`, `read_dir`, `symlink_metadata`, `canonicalize`. Is it
    worth having our own version of `Path` just to exclude those? Such a
    thing could also exclude absolute paths.
- - Should we provide any of Rust's Unix-specific APIs on Windows, using
-   winx and emulation?
  - Should we propose adding things to Rust's libstd which would help streamline this library?
     - A way to construct an arbitrary [`std::fs::FileType`] and [`std::fs::Metadata`]?
     - A way to read the options out of a [`std::fs::OpenOptions`] and [`std::fs::DirBuilder`]?

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -196,8 +196,6 @@ impl io::Seek for File {
 
 // async_std doesn't have `FileExt`.
 
-// TODO: Use winx to implement "unix" FileExt api on Windows?
-
 impl fmt::Debug for File {
     // Like libstd's version, but doesn't print the path.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -200,6 +200,4 @@ impl io::Seek for File {
 
 // async_std doesn't have `FileExt`.
 
-// TODO: Use winx to implement "unix" FileExt api on Windows?
-
 // TODO: impl Debug for File? But don't expose File's path...

--- a/cap-primitives/src/yanix/common/fs/link_unchecked.rs
+++ b/cap-primitives/src/yanix/common/fs/link_unchecked.rs
@@ -16,7 +16,6 @@ pub(crate) fn link_unchecked(
     follow: FollowSymlinks,
 ) -> io::Result<()> {
     // POSIX's `linkat` with an empty path returns `ENOENT`, so use "." instead.
-    // TODO: Use `AT_EMPTY_PATH` instead, on platforms that support it?
     let new_path = if new_path.components().next().is_none() {
         OsStr::new(".")
     } else {

--- a/cap-primitives/src/yanix/common/fs/mkdir_unchecked.rs
+++ b/cap-primitives/src/yanix/common/fs/mkdir_unchecked.rs
@@ -12,7 +12,6 @@ pub(crate) fn mkdir_unchecked(
     path: &Path,
 ) -> io::Result<()> {
     // POSIX's `mkdirat` with an empty path returns `ENOENT`, so use "." instead.
-    // TODO: Use `AT_EMPTY_PATH` instead, on platforms that support it?
     let path = if path.components().next().is_none() {
         OsStr::new(".")
     } else {

--- a/cap-primitives/src/yanix/common/fs/stat_unchecked.rs
+++ b/cap-primitives/src/yanix/common/fs/stat_unchecked.rs
@@ -14,7 +14,6 @@ pub(crate) fn stat_unchecked(
     follow: FollowSymlinks,
 ) -> io::Result<Metadata> {
     // POSIX's `fstatat` with an empty path returns `ENOENT`, so use "." instead.
-    // TODO: Use `AT_EMPTY_PATH` instead, on platforms that support it?
     let path = if path.components().next().is_none() {
         OsStr::new(".")
     } else {

--- a/cap-primitives/src/yanix/common/fs/unlink_unchecked.rs
+++ b/cap-primitives/src/yanix/common/fs/unlink_unchecked.rs
@@ -4,7 +4,6 @@ use yanix::file::{unlinkat, AtFlag};
 /// *Unsandboxed* function similar to `unlink`, but which does not perform sandboxing.
 pub(crate) fn unlink_unchecked(start: &fs::File, path: &Path) -> io::Result<()> {
     // POSIX's `unlinkat` with an empty path returns `ENOENT`, so use "." instead.
-    // TODO: Use `AT_EMPTY_PATH` instead, on platforms that support it?
     let path = if path.components().next().is_none() {
         OsStr::new(".")
     } else {

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -80,8 +80,6 @@ impl Dir {
     /// relative to `self`.
     ///
     /// [`std::fs::create_dir`]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
-    ///
-    /// TODO: Should this return a `Dir` with the newly created directory?
     #[inline]
     pub fn create_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         self.sys.create_dir(path.as_ref())

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -311,8 +311,6 @@ impl std::os::windows::fs::FileExt for File {
     }
 }
 
-// TODO: Use winx to implement "unix" FileExt api on Windows?
-
 impl fmt::Debug for File {
     // Like libstd's version, but doesn't print the path.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/fs_utf8/file.rs
+++ b/src/fs_utf8/file.rs
@@ -313,6 +313,4 @@ impl std::os::windows::fs::FileExt for File {
     }
 }
 
-// TODO: Use winx to implement "unix" FileExt api on Windows?
-
 // TODO: impl Debug for File? But don't expose File's path...


### PR DESCRIPTION
Thinking about these more, I think the thing to focus on here is libstd compatibility, rather than provide new features.

`AT_EMPTY_PATH` doesn't work with most syscalls, and it's not super helpful for our purposes anyway, so drop the TODO for now.