### PR TITLE
Enable more tests

### DIFF
--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -11,9 +11,8 @@ use cap_std::fs::{self, OpenOptions};
 use std::{
     io::{self, ErrorKind, SeekFrom},
     path::{Path, PathBuf},
-    str,
+    str, thread,
 };
-/*use std::thread;*/
 use sys_common::io::{tmpdir, TempDir};
 
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -558,8 +557,8 @@ fn recursive_mkdir_failure() {
     assert!(result.is_err());
 }
 
-/*
 #[test]
+#[ignore] // cap-primitives contains racy checks that fail under threads
 fn concurrent_recursive_mkdir() {
     for _ in 0..100 {
         let dir = tmpdir();
@@ -569,7 +568,7 @@ fn concurrent_recursive_mkdir() {
         }
         let mut join = vec![];
         for _ in 0..8 {
-            let dir = dir.clone();
+            let dir = check!(dir.try_clone());
             let name = name.clone();
             join.push(thread::spawn(move || {
                 check!(dir.create_dir_all(&name));
@@ -580,7 +579,6 @@ fn concurrent_recursive_mkdir() {
         join.drain(..).map(|join| join.join().unwrap()).count();
     }
 }
-*/
 
 #[test]
 fn recursive_mkdir_slash() {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1280,7 +1280,6 @@ fn unlink_readonly() {
 }
 
 #[test]
-#[ignore] // `create_dir_all` not yet implemented in cap-std
 fn mkdir_trailing_slash() {
     let tmpdir = tmpdir();
     let path = PathBuf::from("file");


### PR DESCRIPTION
This uncomments `concurrent_recursive_mkdir`, so now all tests are uncommented. Unfortunately it doesn't pass yet, because it's doing threads which break the racy checks in cap-primitives. I expect we'll eventually make those checks optional, but for now, just `ignore` this test.

Also, enable `mkdir_trailing_slash` as it's passing.