### PR TITLE
Set CLOEXEC on old Linux systems which don't support O_CLOEXEC.

### DIFF
--- a/cap-primitives/src/yanix/linux/fs/ensure_cloexec.rs
+++ b/cap-primitives/src/yanix/linux/fs/ensure_cloexec.rs
@@ -1,7 +1,7 @@
 use std::{io, os::unix::io::RawFd};
 use yanix::{
     fcntl::{get_fd_flags, set_fd_flags},
-    file::FdFlag,
+    file::FdFlags,
 };
 
 // Implementation derived from `ensure_cloexec` in Rust's
@@ -53,12 +53,12 @@ pub(crate) unsafe fn ensure_cloexec(fd: RawFd) -> io::Result<()> {
 // 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
 
 unsafe fn get_cloexec(fd: RawFd) -> io::Result<bool> {
-    Ok(get_fd_flags(fd)?.contains(FdFlag::CLOEXEC))
+    Ok(get_fd_flags(fd)?.contains(FdFlags::CLOEXEC))
 }
 
 unsafe fn set_cloexec(fd: RawFd) -> io::Result<()> {
     let previous = get_fd_flags(fd)?;
-    let new = previous | FdFlag::CLOEXEC;
+    let new = previous | FdFlags::CLOEXEC;
     if new != previous {
         set_fd_flags(fd, new)?;
     }

--- a/cap-primitives/src/yanix/linux/fs/ensure_cloexec.rs
+++ b/cap-primitives/src/yanix/linux/fs/ensure_cloexec.rs
@@ -1,0 +1,66 @@
+use std::{io, os::unix::io::RawFd};
+use yanix::{
+    fcntl::{get_fd_flags, set_fd_flags},
+    file::FdFlag,
+};
+
+// Implementation derived from `ensure_cloexec` in Rust's
+// src/libstd/sys/unix/fs.rs at revision
+// 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
+
+// Currently the standard library supports Linux 2.6.18 which did not
+// have the O_CLOEXEC flag (passed above). If we're running on an older
+// Linux kernel then the flag is just ignored by the OS. After we open
+// the first file, we check whether it has CLOEXEC set. If it doesn't,
+// we will explicitly ask for a CLOEXEC fd for every further file we
+// open, if it does, we will skip that step.
+//
+// The CLOEXEC flag, however, is supported on versions of macOS/BSD/etc
+// that we support, so we only do this on Linux currently.
+pub(crate) unsafe fn ensure_cloexec(fd: RawFd) -> io::Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const OPEN_CLOEXEC_UNKNOWN: usize = 0;
+    const OPEN_CLOEXEC_SUPPORTED: usize = 1;
+    const OPEN_CLOEXEC_NOTSUPPORTED: usize = 2;
+    static OPEN_CLOEXEC: AtomicUsize = AtomicUsize::new(OPEN_CLOEXEC_UNKNOWN);
+
+    let need_to_set;
+    match OPEN_CLOEXEC.load(Ordering::Relaxed) {
+        OPEN_CLOEXEC_UNKNOWN => {
+            need_to_set = !get_cloexec(fd)?;
+            OPEN_CLOEXEC.store(
+                if need_to_set {
+                    OPEN_CLOEXEC_NOTSUPPORTED
+                } else {
+                    OPEN_CLOEXEC_SUPPORTED
+                },
+                Ordering::Relaxed,
+            );
+        }
+        OPEN_CLOEXEC_SUPPORTED => need_to_set = false,
+        OPEN_CLOEXEC_NOTSUPPORTED => need_to_set = true,
+        _ => unreachable!(),
+    }
+    if need_to_set {
+        set_cloexec(fd)?;
+    }
+    Ok(())
+}
+
+// Implementation derived from the Linux variants of `get_cloexec` and
+// `set_cloexec` in Rust's src/libstd/sys/unix/fd.rs at revision
+// 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
+
+unsafe fn get_cloexec(fd: RawFd) -> io::Result<bool> {
+    Ok(get_fd_flags(fd)?.contains(FdFlag::CLOEXEC))
+}
+
+unsafe fn set_cloexec(fd: RawFd) -> io::Result<()> {
+    let previous = get_fd_flags(fd)?;
+    let new = previous | FdFlag::CLOEXEC;
+    if new != previous {
+        set_fd_flags(fd, new)?;
+    }
+    Ok(())
+}

--- a/cap-primitives/src/yanix/linux/fs/mod.rs
+++ b/cap-primitives/src/yanix/linux/fs/mod.rs
@@ -1,3 +1,5 @@
+mod ensure_cloexec;
 mod open_impl;
 
+pub(crate) use ensure_cloexec::*;
 pub(crate) use open_impl::*;

--- a/cap-primitives/src/yanix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/open_impl.rs
@@ -84,6 +84,9 @@ pub(crate) fn open_impl(
                         errno => return other_error(errno),
                     },
                     ret => {
+                        // Note that we don't bother with `ensure_cloexec` here
+                        // because Linux has supported `O_CLOEXEC` since 2.6.18,
+                        // and `openat2` was introduced in 5.6.
                         let file = fs::File::from_raw_fd(ret as RawFd);
 
                         #[cfg(debug_assertions)]


### PR DESCRIPTION
There will be a separate patch to enable `O_CLOEXEC` in general, once we update to yanix 0.19.