### PR TITLE
Use `open` in `open_parent`.

### DIFF
--- a/cap-primitives/src/fs/canonicalize_manually.rs
+++ b/cap-primitives/src/fs/canonicalize_manually.rs
@@ -1,7 +1,7 @@
 //! Manual path canonicalization, one component at a time, with manual symlink
 //! resolution, in order to enforce sandboxing.
 
-use crate::fs::{open_manually, FollowSymlinks, OpenOptions};
+use crate::fs::{open_manually, FollowSymlinks, MaybeOwnedFile, OpenOptions};
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -26,6 +26,7 @@ pub(crate) fn canonicalize_manually(
 ) -> io::Result<PathBuf> {
     let mut symlink_count = 0;
     let mut canonical_path = PathBuf::new();
+    let start = MaybeOwnedFile::borrowed(start);
 
     if let Err(e) = open_manually(
         start,

--- a/cap-primitives/src/fs/link_via_parent.rs
+++ b/cap-primitives/src/fs/link_via_parent.rs
@@ -9,17 +9,16 @@ pub(crate) fn link_via_parent(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let mut symlink_count = 0;
-    let mut old_start = MaybeOwnedFile::borrowed(old_start);
-    let mut new_start = MaybeOwnedFile::borrowed(new_start);
+    let old_start = MaybeOwnedFile::borrowed(old_start);
+    let new_start = MaybeOwnedFile::borrowed(new_start);
 
-    let old_basename = open_parent(&mut old_start, old_path, &mut symlink_count)?;
-    let new_basename = open_parent(&mut new_start, new_path, &mut symlink_count)?;
+    let (old_dir, old_basename) = open_parent(old_start, old_path)?;
+    let (new_dir, new_basename) = open_parent(new_start, new_path)?;
 
     link_unchecked(
-        &old_start,
+        &old_dir,
         old_basename.as_ref(),
-        &new_start,
+        &new_dir,
         new_basename.as_ref(),
         FollowSymlinks::No,
     )

--- a/cap-primitives/src/fs/mkdir_via_parent.rs
+++ b/cap-primitives/src/fs/mkdir_via_parent.rs
@@ -4,14 +4,13 @@ use std::{fs, io, path::Path};
 /// Implement `mkdir` by `open`ing up the parent component of the path and then
 /// calling `mkdir_unchecked` on the last component.
 pub(crate) fn mkdir_via_parent(start: &fs::File, path: &Path) -> io::Result<()> {
-    let mut symlink_count = 0;
-    let mut start = MaybeOwnedFile::borrowed(start);
+    let start = MaybeOwnedFile::borrowed(start);
 
     // As a special case, `mkdir` ignores a trailing slash rather than treating
     // it as equivalent to a trailing slash-dot, so strip any trailing slashes.
     let path = strip_dir_suffix(path);
 
-    let basename = open_parent(&mut start, path, &mut symlink_count)?;
+    let (dir, basename) = open_parent(start, path)?;
 
-    mkdir_unchecked(&start, basename.as_ref())
+    mkdir_unchecked(&dir, basename.as_ref())
 }

--- a/cap-primitives/src/fs/open.rs
+++ b/cap-primitives/src/fs/open.rs
@@ -5,7 +5,7 @@ use std::{fs, io, path::Path};
 #[cfg(debug_assertions)]
 use {
     super::get_path,
-    crate::fs::{is_same_file, open_unchecked, stat_unchecked, Metadata, OpenUncheckedError},
+    crate::fs::{is_same_file, open_unchecked, stat_unchecked, Metadata},
 };
 
 /// Perform an `openat`-like operation, ensuring that the resolution of the path
@@ -81,11 +81,7 @@ fn check_open(
             Err(result_error) => match result_error.kind() {
                 io::ErrorKind::PermissionDenied | io::ErrorKind::InvalidInput => (),
                 _ => {
-                    let _unchecked_error = match unchecked_error {
-                        OpenUncheckedError::Other(err)
-                        | OpenUncheckedError::Symlink(err)
-                        | OpenUncheckedError::NotFound(err) => err,
-                    };
+                    let _unchecked_error = unchecked_error.into_io_error();
                     /* TODO: Check error messages.
                     assert_eq!(result_error.to_string(), unchecked_error.to_string());
                     assert_eq!(result_error.kind(), unchecked_error.kind());

--- a/cap-primitives/src/fs/readlink_via_parent.rs
+++ b/cap-primitives/src/fs/readlink_via_parent.rs
@@ -7,10 +7,9 @@ use std::{
 /// Implement `readlink` by `open`ing up the parent component of the path and then
 /// calling `readlink_unchecked` on the last component.
 pub fn readlink_via_parent(start: &fs::File, path: &Path) -> io::Result<PathBuf> {
-    let mut symlink_count = 0;
-    let mut start = MaybeOwnedFile::borrowed(start);
+    let start = MaybeOwnedFile::borrowed(start);
 
-    let basename = open_parent(&mut start, path, &mut symlink_count)?;
+    let (dir, basename) = open_parent(start, path)?;
 
-    readlink_unchecked(&start, basename.as_ref())
+    readlink_unchecked(&dir, basename.as_ref())
 }

--- a/cap-primitives/src/fs/rename_via_parent.rs
+++ b/cap-primitives/src/fs/rename_via_parent.rs
@@ -9,22 +9,21 @@ pub fn rename_via_parent(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    let mut symlink_count = 0;
-    let mut old_start = MaybeOwnedFile::borrowed(old_start);
-    let mut new_start = MaybeOwnedFile::borrowed(new_start);
+    let old_start = MaybeOwnedFile::borrowed(old_start);
+    let new_start = MaybeOwnedFile::borrowed(new_start);
 
     // As a special case, `rename` ignores a trailing slash rather than treating
     // it as equivalent to a trailing slash-dot, so strip any trailing slashes.
     let old_path = strip_dir_suffix(old_path);
     let new_path = strip_dir_suffix(new_path);
 
-    let old_basename = open_parent(&mut old_start, old_path, &mut symlink_count)?;
-    let new_basename = open_parent(&mut new_start, new_path, &mut symlink_count)?;
+    let (old_dir, old_basename) = open_parent(old_start, old_path)?;
+    let (new_dir, new_basename) = open_parent(new_start, new_path)?;
 
     rename_unchecked(
-        &old_start,
+        &old_dir,
         old_basename.as_ref(),
-        &new_start,
+        &new_dir,
         new_basename.as_ref(),
     )
 }

--- a/cap-primitives/src/fs/rmdir_via_parent.rs
+++ b/cap-primitives/src/fs/rmdir_via_parent.rs
@@ -4,10 +4,9 @@ use std::{fs, io, path::Path};
 /// Implement `rmdir` by `open`ing up the parent component of the path and then
 /// calling `rmdir_unchecked` on the last component.
 pub(crate) fn rmdir_via_parent(start: &fs::File, path: &Path) -> io::Result<()> {
-    let mut symlink_count = 0;
-    let mut start = MaybeOwnedFile::borrowed(start);
+    let start = MaybeOwnedFile::borrowed(start);
 
-    let basename = open_parent(&mut start, path, &mut symlink_count)?;
+    let (dir, basename) = open_parent(start, path)?;
 
-    rmdir_unchecked(&start, basename.as_ref())
+    rmdir_unchecked(&dir, basename.as_ref())
 }

--- a/cap-primitives/src/fs/symlink_via_parent.rs
+++ b/cap-primitives/src/fs/symlink_via_parent.rs
@@ -15,12 +15,11 @@ pub(crate) fn symlink_via_parent(
     new_path: &Path,
 ) -> io::Result<()> {
     use crate::fs::symlink_unchecked;
-    let mut symlink_count = 0;
-    let mut new_start = MaybeOwnedFile::borrowed(new_start);
+    let new_start = MaybeOwnedFile::borrowed(new_start);
 
-    let new_basename = open_parent(&mut new_start, new_path, &mut symlink_count)?;
+    let (new_dir, new_basename) = open_parent(new_start, new_path)?;
 
-    symlink_unchecked(old_path, &new_start, new_basename.as_ref())
+    symlink_unchecked(old_path, &new_dir, new_basename.as_ref())
 }
 
 /// Implement `symlink_file` by `open`ing up the parent component of the path and then

--- a/cap-primitives/src/fs/unlink_via_parent.rs
+++ b/cap-primitives/src/fs/unlink_via_parent.rs
@@ -4,10 +4,9 @@ use std::{fs, io, path::Path};
 /// Implement `unlink` by `open`ing up the parent component of the path and then
 /// calling `unlink_unchecked` on the last component.
 pub(crate) fn unlink_via_parent(start: &fs::File, path: &Path) -> io::Result<()> {
-    let mut symlink_count = 0;
-    let mut start = MaybeOwnedFile::borrowed(start);
+    let start = MaybeOwnedFile::borrowed(start);
 
-    let basename = open_parent(&mut start, path, &mut symlink_count)?;
+    let (dir, basename) = open_parent(start, path)?;
 
-    unlink_unchecked(&start, basename.as_ref())
+    unlink_unchecked(&dir, basename.as_ref())
 }

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -2,6 +2,7 @@ mod dir_entry_inner;
 mod dir_options;
 mod file_type_ext;
 mod flags;
+#[cfg(debug_assertions)]
 mod is_same_file;
 mod link_unchecked;
 mod metadata_ext;
@@ -40,6 +41,7 @@ pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options::*;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
+#[cfg(debug_assertions)]
 pub(crate) use is_same_file::*;
 pub(crate) use link_unchecked::*;
 pub(crate) use metadata_ext::*;


### PR DESCRIPTION
Use regular `open` in `open_parent`, to take advantage of optimizations
such as `openat2`.

This also adjusts the interface of `open_manually` and `open_parent` to
operate in terms of `MaybeOwnedFile` arguments and return types rather
than mutable references, which makes working with the borrow checker
a little easier.

`stat` still needs `open_manually`, so that it can use a a single symlink
count across multple calls, so create a separate `open_parent_manually`
for it.