### PR TITLE
Use `O_CLOEXEC` on Unix-family platforms.

### DIFF
--- a/cap-primitives/src/yanix/fs/flags.rs
+++ b/cap-primitives/src/yanix/fs/flags.rs
@@ -3,8 +3,7 @@ use std::io;
 use yanix::file::OFlags;
 
 pub(crate) fn compute_oflags(options: &OpenOptions) -> io::Result<OFlags> {
-    // TODO: Add `CLOEXEC` when yanix is updated.
-    let mut oflags = OFlags::empty();
+    let mut oflags = OFlags::CLOEXEC;
     oflags |= get_access_mode(options)?;
     oflags |= get_creation_mode(options)?;
     if options.follow == FollowSymlinks::No {


### PR DESCRIPTION
Follow libstd in enabling `O_CLOEXEC` on all file descriptors opened
with this library.