### PR TITLE
Optimize `stat` on Linux using `openat2` and `O_PATH`.

### DIFF
--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -269,7 +269,7 @@ fn check_open(
     ) {
         Ok(unchecked_file) => {
             assert!(
-                is_same_file(&base, &unchecked_file).unwrap(),
+                is_same_file(base, &unchecked_file).unwrap(),
                 "path resolution inconsistency: start='{:?}', path='{}'; canonical_path='{}'; \
                  got='{:?}' expected='{:?}'",
                 start,

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -201,7 +201,7 @@ impl arbitrary::Arbitrary for OpenOptions {
             _ => panic!(),
         };
         // TODO: `OpenOptionsExt` options.
-        Ok(OpenOptions::new()
+        Ok(Self::new()
             .read(read)
             .write(write)
             .create(<bool as Arbitrary>::arbitrary(u)?)

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -18,6 +18,20 @@ mod stat_unchecked;
 mod symlink_unchecked;
 mod unlink_unchecked;
 
+#[rustfmt::skip]
+pub(crate) use crate::fs::{
+    canonicalize_manually_and_follow as canonicalize_impl,
+    link_via_parent as link_impl,
+    mkdir_via_parent as mkdir_impl,
+    readlink_via_parent as readlink_impl,
+    rename_via_parent as rename_impl,
+    rmdir_via_parent as rmdir_impl,
+    stat_via_parent as stat_impl,
+    symlink_dir_via_parent as symlink_dir_impl,
+    symlink_file_via_parent as symlink_file_impl,
+    unlink_via_parent as unlink_impl,
+};
+
 pub(crate) mod errors;
 
 pub(crate) use crate::fs::open_manually_wrapper as open_impl;
@@ -40,11 +54,3 @@ pub(crate) use rmdir_unchecked::*;
 pub(crate) use stat_unchecked::*;
 pub(crate) use symlink_unchecked::*;
 pub(crate) use unlink_unchecked::*;
-
-pub(crate) use crate::fs::{
-    canonicalize_manually_and_follow as canonicalize_impl, link_via_parent as link_impl,
-    mkdir_via_parent as mkdir_impl, readlink_via_parent as readlink_impl,
-    rename_via_parent as rename_impl, rmdir_via_parent as rmdir_impl, stat_via_parent as stat_impl,
-    symlink_dir_via_parent as symlink_dir_impl, symlink_file_via_parent as symlink_file_impl,
-    unlink_via_parent as unlink_impl,
-};

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -25,14 +25,20 @@ cfg_if::cfg_if! {
         pub(crate) use crate::yanix::linux::fs::*;
     } else {
         pub(crate) use crate::fs::open_manually_wrapper as open_impl;
+        pub(crate) use crate::fs::stat_via_parent as stat_impl;
     }
 }
 
+#[rustfmt::skip]
 pub(crate) use crate::fs::{
-    canonicalize_manually_and_follow as canonicalize_impl, link_via_parent as link_impl,
-    mkdir_via_parent as mkdir_impl, readlink_via_parent as readlink_impl,
-    rename_via_parent as rename_impl, rmdir_via_parent as rmdir_impl, stat_via_parent as stat_impl,
-    symlink_via_parent as symlink_impl, unlink_via_parent as unlink_impl,
+    canonicalize_manually_and_follow as canonicalize_impl,
+    link_via_parent as link_impl,
+    mkdir_via_parent as mkdir_impl,
+    readlink_via_parent as readlink_impl,
+    rename_via_parent as rename_impl,
+    rmdir_via_parent as rmdir_impl,
+    symlink_via_parent as symlink_impl,
+    unlink_via_parent as unlink_impl,
 };
 
 pub(crate) mod errors;

--- a/cap-primitives/src/yanix/fs/readlink_one.rs
+++ b/cap-primitives/src/yanix/fs/readlink_one.rs
@@ -17,12 +17,12 @@ pub(crate) fn readlink_one(
 ) -> io::Result<PathBuf> {
     let name: &Path = name.as_ref();
     assert!(
-        name.file_name().is_some(),
+        name.as_os_str().is_empty() || name.file_name().is_some(),
         "readlink_one expects a single normal path component, got '{}'",
         name.display()
     );
     assert!(
-        name.parent().unwrap().as_os_str().is_empty(),
+        name.as_os_str().is_empty() || name.parent().unwrap().as_os_str().is_empty(),
         "readlink_one expects a single normal path component, got '{}'",
         name.display()
     );

--- a/cap-primitives/src/yanix/linux/fs/mod.rs
+++ b/cap-primitives/src/yanix/linux/fs/mod.rs
@@ -1,5 +1,11 @@
 mod ensure_cloexec;
 mod open_impl;
+mod stat_impl;
 
 pub(crate) use ensure_cloexec::*;
 pub(crate) use open_impl::*;
+pub(crate) use stat_impl::*;
+
+// In theory we could optimize `link` using `openat2` with `O_PATH` and
+// `linkat` with `AT_EMPTY_PATH`, however that requires `CAP_DAC_READ_SEARCH`,
+// so it isn't very widely applicable.

--- a/cap-primitives/src/yanix/linux/fs/stat_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/stat_impl.rs
@@ -7,7 +7,6 @@ use std::{fs, io, path::Path};
 
 /// Use `openat2` with `O_PATH` and `fstat`. If that's not available, fallback
 /// to `stat_via_parent`.
-#[inline]
 pub(crate) fn stat_impl(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/yanix/linux/fs/stat_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/stat_impl.rs
@@ -1,0 +1,40 @@
+//! Linux has an `O_PATH` flag which allows opening a file without necessary
+//! having read or write access to it; we can use that with `openat2` and
+//! `fstat` to perform a fast sandboxed `stat`.
+
+use crate::fs::{open_with_openat2, stat_via_parent, FollowSymlinks, Metadata, OpenOptions};
+use std::{fs, io, path::Path};
+
+/// Use `openat2` with `O_PATH` and `fstat`. If that's not available, fallback
+/// to `stat_via_parent`.
+#[inline]
+pub(crate) fn stat_impl(
+    start: &fs::File,
+    path: &Path,
+    follow: FollowSymlinks,
+) -> io::Result<Metadata> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // Open the path with `O_PATH`. Use `read(true) even though we don't need
+    // `read` permissions, because Rust's libstd requires an access mode, and
+    // Linux ignores `O_RDONLY` with `O_PATH`.
+    let result = open_with_openat2(
+        start,
+        path,
+        OpenOptions::new()
+            .read(true)
+            .follow(follow)
+            .custom_flags(libc::O_PATH),
+    );
+
+    // If that worked, call `fstat`.
+    match result {
+        Ok(file) => file.metadata().map(Metadata::from_std),
+        Err(err) => match err.raw_os_error() {
+            // `ENOSYS` from `open_with_openat2` means `openat2` is unavailable
+            // and we should use a fallback.
+            Some(libc::ENOSYS) => stat_via_parent(start, path, follow),
+            _ => Err(err),
+        },
+    }
+}


### PR DESCRIPTION
`stat_via_parent` is the main user of `open_parent_manually`, so on systems
with `openat2`, this avoids one of the few remaining manual path lookups.