### PR TITLE
Optimize `open_manually` to do fewer heap allocations

### DIFF
--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -158,7 +158,7 @@ pub(crate) fn open_manually<'start>(
         .rev()
         .collect::<Vec<_>>();
     let mut base = start;
-    let mut dirs = Vec::new();
+    let mut dirs = Vec::with_capacity(components.len());
     let mut canonical_path = CanonicalPath::new(canonical_path);
     let dir_options = dir_options();
 


### PR DESCRIPTION
In a long path with no symlinks, this reduces the number of instructions executed by about 15%, according to `perf`.