### PR TITLE
Add first pass at open_unchecked on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,14 @@ yanix = "0.19.0"
 yanix = "0.19.0"
 
 [dev-dependencies]
-libc = "0.2.72"
 rand = "0.7.3"
 uuid = { version = "0.8", features = ["v4"] }
+
+[target.'cfg(not(windows))'.dev-dependencies]
+libc = "0.2.72"
+
+[target.'cfg(windows)'.dev-dependencies]
+winx = "0.19.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-primitives/src/winx/fs/flags.rs
+++ b/cap-primitives/src/winx/fs/flags.rs
@@ -1,0 +1,24 @@
+use crate::fs::{FollowSymlinks, OpenOptions};
+use std::{fs, os::windows::fs::OpenOptionsExt};
+use winx::file::Flags;
+
+pub(super) fn open_options_to_std(opts: &OpenOptions) -> fs::OpenOptions {
+    let custom_flags = match opts.follow {
+        FollowSymlinks::Yes => opts.ext.custom_flags,
+        FollowSymlinks::No => opts.ext.custom_flags | Flags::FILE_FLAG_OPEN_REPARSE_POINT.bits(),
+    };
+    let mut std_opts = fs::OpenOptions::new();
+    std_opts
+        .read(opts.read)
+        .write(opts.write)
+        .append(opts.append)
+        .truncate(opts.truncate)
+        .create(opts.create)
+        .create_new(opts.create_new)
+        .access_mode(opts.ext.access_mode)
+        .share_mode(opts.ext.share_mode)
+        .custom_flags(custom_flags)
+        .attributes(opts.ext.attributes)
+        .security_qos_flags(opts.ext.security_qos_flags);
+    std_opts
+}

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -1,6 +1,7 @@
 mod dir_entry_inner;
 mod dir_options;
 mod file_type_ext;
+mod flags;
 mod get_path;
 mod is_same_file;
 mod link_unchecked;
@@ -37,6 +38,7 @@ pub(crate) use crate::fs::open_manually_wrapper as open_impl;
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options::*;
 pub(crate) use file_type_ext::*;
+pub(crate) use flags::*;
 pub(crate) use get_path::get_path as get_path_impl;
 pub(crate) use is_same_file::*;
 pub(crate) use link_unchecked::*;

--- a/cap-primitives/src/winx/fs/open_unchecked.rs
+++ b/cap-primitives/src/winx/fs/open_unchecked.rs
@@ -1,5 +1,7 @@
+use super::{get_path::concatenate_or_return_absolute, open_options_to_std};
 use crate::fs::{OpenOptions, OpenUncheckedError};
-use std::{fs, path::Path};
+use std::{fs, io, path::Path};
+use winapi::shared::winerror;
 
 /// *Unsandboxed* function similar to `open`, but which does not perform sandboxing.
 pub(crate) fn open_unchecked(
@@ -7,5 +9,23 @@ pub(crate) fn open_unchecked(
     path: &Path,
     options: &OpenOptions,
 ) -> Result<fs::File, OpenUncheckedError> {
-    todo!("open_unchecked")
+    let full_path =
+        concatenate_or_return_absolute(start, path).map_err(OpenUncheckedError::Other)?;
+    let opts = open_options_to_std(options);
+    match opts.open(full_path) {
+        Ok(f) => Ok(f),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Err(OpenUncheckedError::NotFound(e)),
+        Err(e) => match e.raw_os_error() {
+            Some(code) => match code as u32 {
+                winerror::ERROR_FILE_NOT_FOUND | winerror::ERROR_PATH_NOT_FOUND => {
+                    Err(OpenUncheckedError::NotFound(e))
+                }
+                winerror::ERROR_REPARSE | winerror::ERROR_REPARSE_OBJECT => {
+                    Err(OpenUncheckedError::Symlink(e))
+                }
+                _ => Err(OpenUncheckedError::Other(e)),
+            },
+            None => Err(OpenUncheckedError::Other(e)),
+        },
+    }
 }


### PR DESCRIPTION
Also, fix dev-dependencies which need to include `libc` on POSIX, and `winx` on Windows.

We're still missing a couple of syscalls to start running some tests though, so this will go untested for now.