### PR TITLE
Put the racy assertions under their own cargo feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 ipnet = "2.3.0"
 cfg-if = "0.1.9"
 arf-strings = { version = "0.1.2", optional = true }
-cap-primitives = { path = "cap-primitives", version = "0.0.0" }
+cap-primitives = { path = "cap-primitives", version = "0.0.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 yanix = "0.19.0"
@@ -39,8 +39,9 @@ winx = "0.19.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = []
+default = ["no_racy_asserts"]
 fs_utf8 = ["arf-strings"]
+no_racy_asserts = ["cap-primitives/no_racy_asserts"]
 
 [workspace]
 members = [

--- a/cap-async-std/Cargo.toml
+++ b/cap-async-std/Cargo.toml
@@ -15,7 +15,7 @@ async-std = { version = "1.6.2", features = ["attributes"] }
 ipnet = "2.3.0"
 cfg-if = "0.1.9"
 arf-strings = { version = "0.1.2", optional = true }
-cap-primitives = { path = "../cap-primitives", version = "0.0.0" }
+cap-primitives = { path = "../cap-primitives", version = "0.0.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 yanix = "0.19.0"
@@ -30,5 +30,6 @@ yanix = "0.19.0"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = []
+default = ["no_racy_asserts"]
 fs_utf8 = ["arf-strings"]
+no_racy_asserts = ["cap-primitives/no_racy_asserts"]

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -43,5 +43,9 @@ winapi = { version = "0.3.9", features = [
     "aclapi"
 ] }
 
+[features]
+default = ["no_racy_asserts"]
+no_racy_asserts = []
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-primitives/src/fs/link.rs
+++ b/cap-primitives/src/fs/link.rs
@@ -1,13 +1,13 @@
 //! This defines `link`, the primary entrypoint to sandboxed hard-link creation.
 
 use crate::fs::link_impl;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 use crate::fs::{canonicalize, link_unchecked, stat_unchecked, FollowSymlinks, Metadata};
 use std::{fs, io, path::Path};
 
 /// Perform a `linkat`-like operation, ensuring that the resolution of the path
 /// never escapes the directory tree rooted at `start`.
-#[cfg_attr(not(debug_assertions), allow(clippy::let_and_return))]
+#[cfg_attr(feature = "no_racy_asserts", allow(clippy::let_and_return))]
 #[inline]
 pub fn link(
     old_start: &fs::File,
@@ -15,7 +15,7 @@ pub fn link(
     new_start: &fs::File,
     new_path: &Path,
 ) -> io::Result<()> {
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     let (old_metadata_before, new_metadata_before) = (
         stat_unchecked(old_start, old_path, FollowSymlinks::No),
         stat_unchecked(new_start, new_path, FollowSymlinks::No),
@@ -24,14 +24,13 @@ pub fn link(
     // Call the underlying implementation.
     let result = link_impl(old_start, old_path, new_start, new_path);
 
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     let (old_metadata_after, new_metadata_after) = (
         stat_unchecked(old_start, old_path, FollowSymlinks::No),
         stat_unchecked(new_start, new_path, FollowSymlinks::No),
     );
 
-    // TODO: This is a racy check, though it is useful for testing and fuzzing.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     check_link(
         old_start,
         old_path,
@@ -47,9 +46,9 @@ pub fn link(
     result
 }
 
+#[cfg(not(feature = "no_racy_asserts"))]
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::enum_glob_use)]
-#[cfg(debug_assertions)]
 fn check_link(
     old_start: &fs::File,
     old_path: &Path,

--- a/cap-primitives/src/fs/metadata.rs
+++ b/cap-primitives/src/fs/metadata.rs
@@ -123,7 +123,7 @@ impl Metadata {
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same device.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     pub(crate) fn is_same_file(&self, other: &Self) -> bool {
         self.ext.is_same_file(&other.ext)
     }

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -7,7 +7,7 @@ mod dir_entry;
 mod dir_options;
 mod file_type;
 mod follow_symlinks;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 mod get_path;
 mod link;
 mod link_via_parent;
@@ -38,7 +38,7 @@ mod unlink;
 mod unlink_via_parent;
 
 pub(crate) use canonicalize_manually::*;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 pub(crate) use get_path::*;
 pub(crate) use link_via_parent::*;
 pub(crate) use maybe_owned_file::*;
@@ -85,7 +85,7 @@ pub use stat::*;
 pub use symlink::*;
 pub use unlink::*;
 
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 fn map_result<T: Clone>(result: &std::io::Result<T>) -> Result<T, (std::io::ErrorKind, String)> {
     match result {
         Ok(t) => Ok(t.clone()),

--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -1,7 +1,7 @@
 //! Manual path resolution, one component at a time, with manual symlink
 //! resolution, in order to enforce sandboxing.
 
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 use crate::fs::is_same_file;
 use crate::fs::{
     dir_options, errors, open_unchecked, path_requires_dir, readlink_one, FollowSymlinks,
@@ -52,14 +52,14 @@ struct CanonicalPath<'path_buf> {
     path: Option<&'path_buf mut PathBuf>,
 
     /// Our own private copy of the canonical path, for assertion checking.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     debug: PathBuf,
 }
 
 impl<'path_buf> CanonicalPath<'path_buf> {
     fn new(path: Option<&'path_buf mut PathBuf>) -> Self {
         Self {
-            #[cfg(debug_assertions)]
+            #[cfg(not(feature = "no_racy_asserts"))]
             debug: PathBuf::new(),
 
             path,
@@ -67,7 +67,7 @@ impl<'path_buf> CanonicalPath<'path_buf> {
     }
 
     fn push(&mut self, one: &OsStr) {
-        #[cfg(debug_assertions)]
+        #[cfg(not(feature = "no_racy_asserts"))]
         self.debug.push(one);
 
         if let Some(path) = &mut self.path {
@@ -76,7 +76,7 @@ impl<'path_buf> CanonicalPath<'path_buf> {
     }
 
     fn pop(&mut self) -> bool {
-        #[cfg(debug_assertions)]
+        #[cfg(not(feature = "no_racy_asserts"))]
         self.debug.pop();
 
         if let Some(path) = &mut self.path {
@@ -142,7 +142,7 @@ pub(crate) fn open_manually<'start>(
     symlink_count: &mut u8,
     canonical_path: Option<&mut PathBuf>,
 ) -> io::Result<MaybeOwnedFile<'start>> {
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     let start_clone = MaybeOwnedFile::owned(start.try_clone().unwrap());
 
     // POSIX returns `ENOENT` on an empty path. TODO: On Windows, we should
@@ -186,8 +186,7 @@ pub(crate) fn open_manually<'start>(
                 continue;
             }
             CowComponent::ParentDir => {
-                // TODO: This is a racy check, though it is useful for testing and fuzzing.
-                #[cfg(debug_assertions)]
+                #[cfg(not(feature = "no_racy_asserts"))]
                 assert!(dirs.is_empty() || !is_same_file(&start_clone, &base)?);
 
                 if components.is_empty() && dir_precluded {
@@ -270,8 +269,7 @@ pub(crate) fn open_manually<'start>(
         }
     }
 
-    // TODO: This is a racy check, though it is useful for testing and fuzzing.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     check_open(&start_clone, path, options, &canonical_path, &base);
 
     canonical_path.complete();
@@ -286,7 +284,7 @@ fn should_emulate_o_path(use_options: &OpenOptions) -> bool {
         && use_options.follow == FollowSymlinks::Yes
 }
 
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 fn check_open(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/fs/unlink.rs
+++ b/cap-primitives/src/fs/unlink.rs
@@ -1,7 +1,7 @@
 //! This defines `unlink`, the primary entrypoint to sandboxed file removal.
 
 use crate::fs::unlink_impl;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 use crate::fs::{
     canonicalize_manually, stat_unchecked, unlink_unchecked, FollowSymlinks, Metadata,
 };
@@ -9,27 +9,26 @@ use std::{fs, io, path::Path};
 
 /// Perform a `unlinkat`-like operation, ensuring that the resolution of the path
 /// never escapes the directory tree rooted at `start`.
-#[cfg_attr(not(debug_assertions), allow(clippy::let_and_return))]
+#[cfg_attr(feature = "no_racy_asserts", allow(clippy::let_and_return))]
 #[inline]
 pub fn unlink(start: &fs::File, path: &Path) -> io::Result<()> {
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     let stat_before = stat_unchecked(start, path, FollowSymlinks::No);
 
     // Call the underlying implementation.
     let result = unlink_impl(start, path);
 
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     let stat_after = stat_unchecked(start, path, FollowSymlinks::No);
 
-    // TODO: This is a racy check, though it is useful for testing and fuzzing.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     check_unlink(start, path, &stat_before, &result, &stat_after);
 
     result
 }
 
+#[cfg(not(feature = "no_racy_asserts"))]
 #[allow(clippy::enum_glob_use)]
-#[cfg(debug_assertions)]
 fn check_unlink(
     start: &fs::File,
     path: &Path,

--- a/cap-primitives/src/winx/fs/dir_utils.rs
+++ b/cap-primitives/src/winx/fs/dir_utils.rs
@@ -1,5 +1,5 @@
 use crate::fs::OpenOptions;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 use std::path::PathBuf;
 use std::{
     ffi::{OsStr, OsString},
@@ -24,7 +24,7 @@ pub(crate) fn path_requires_dir(path: &Path) -> bool {
 
 // Append a trailing `/`. This can be used to require that the given `path`
 // names a directory.
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 pub(crate) fn append_dir_suffix(path: PathBuf) -> PathBuf {
     let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
     wide.push('/' as u16);

--- a/cap-primitives/src/winx/fs/metadata_ext.rs
+++ b/cap-primitives/src/winx/fs/metadata_ext.rs
@@ -32,7 +32,7 @@ impl MetadataExt {
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same device.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     pub(crate) fn is_same_file(&self, other: &Self) -> bool {
         // From [MSDN]:
         // The identifier (low and high parts) and the volume serial number

--- a/cap-primitives/src/yanix/fs/dir_utils.rs
+++ b/cap-primitives/src/yanix/fs/dir_utils.rs
@@ -4,7 +4,7 @@ use std::{
     os::unix::{ffi::OsStrExt, fs::OpenOptionsExt},
     path::Path,
 };
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::PathBuf};
 use yanix::file::OFlags;
 
@@ -22,7 +22,7 @@ pub(crate) fn path_requires_dir(path: &Path) -> bool {
 
 // Append a trailing `/`. This can be used to require that the given `path`
 // names a directory.
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 pub(crate) fn append_dir_suffix(path: PathBuf) -> PathBuf {
     let mut bytes = path.into_os_string().into_vec();
     bytes.push(b'/');

--- a/cap-primitives/src/yanix/fs/metadata_ext.rs
+++ b/cap-primitives/src/yanix/fs/metadata_ext.rs
@@ -85,7 +85,7 @@ impl MetadataExt {
     }
 
     /// Determine if `self` and `other` refer to the same inode on the same device.
-    #[cfg(debug_assertions)]
+    #[cfg(not(feature = "no_racy_asserts"))]
     pub(crate) fn is_same_file(&self, other: &Self) -> bool {
         self.dev == other.dev && self.ino == other.ino
     }

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -3,7 +3,7 @@ mod dir_options_ext;
 mod dir_utils;
 mod file_type_ext;
 mod flags;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 mod is_same_file;
 mod link_unchecked;
 mod metadata_ext;
@@ -48,7 +48,7 @@ pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
-#[cfg(debug_assertions)]
+#[cfg(not(feature = "no_racy_asserts"))]
 pub(crate) use is_same_file::*;
 pub(crate) use link_unchecked::*;
 pub(crate) use metadata_ext::*;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,10 @@ cargo-fuzz = true
 libfuzzer-sys = "0.3.2"
 arbitrary = { version = "0.4.5", features = ["derive"] }
 tempfile = "3.1.0"
-cap-primitives = { path = "../cap-primitives", features = ["arbitrary"] }
+# Disable default features, including `no_racy_asserts`, because we want to
+# enable the racy asserts, because the cap-primitives fuzz target doesn't
+# use threads, and does want extra checking.
+cap-primitives = { path = "../cap-primitives", default-features = false, features = ["arbitrary"] }
 
 [[bin]]
 name = "cap-primitives"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -6,8 +6,8 @@ via `cargo-fuzz` plugin.
 Currently, there is only a simple fuzzer for the `cap-primitives` crate which constructs
 random paths and attempts random filesystem operations on them. If `cap-primitives`'
 sandbox is working as intended, these operations either stay within a temporary directory
-or fail. Many of the operations in `cap-primitives` have backup checks in `debug_assertions`
-builds, to diagnose sandbox escapes.
+or fail. Many of the operations in `cap-primitives` have backup checks in
+`not(feature = "no_racy_asserts")` builds, to diagnose sandbox escapes.
 
 Caution is recommended when running this fuzzer, since it is a filesystem
 fuzzer, and if it should find a way to escape the sandbox and avoid the


### PR DESCRIPTION
Instead of using `cfg(debug_assertions)`, use
`cfg(not(no_racy_asserts))`. The double-negative there comes from
following the rule that cargo features are additive, so if some code
depending on cap-std needs it to be non-racy, other code depending
on it shouldn't re-enable the asserts.