### PR TITLE
Re-add winx as a dev-dependency for cap-std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,19 @@ yanix = "0.19.0"
 [target.'cfg(target_os = "fuchsia")'.dependencies]
 yanix = "0.19.0"
 
-[dev-dependencies]
+[target.'cfg(windows)'.dev-dependencies]
+winx = "0.19.0"
+
+[target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.72"
+
+[target.'cfg(target_os = "wasi")'.dev-dependencies]
+libc = "0.2.72"
+
+[target.'cfg(target_os = "fuchsia")'.dev-dependencies]
+libc = "0.2.72"
+
+[dev-dependencies]
 rand = "0.7.3"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -95,8 +95,7 @@ impl Dir {
     #[inline]
     pub fn open_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
         let file = unsafe { as_sync(&self.std_file) };
-        open_dir(&file, path.as_ref())
-            .map(|file| Self::from_std_file(File::from_std(file.into()).std))
+        open_dir(&file, path.as_ref()).map(|file| Self::from_std_file(file.into()))
     }
 
     /// Creates a new, empty directory at the provided path.


### PR DESCRIPTION
This fixes cargo test with windows targets.

While here, make the libc dev-dependency conditional.