### PR TITLE
Port a few more tests from Rust.

### DIFF
--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -260,9 +260,10 @@ pub(crate) fn open_manually<'start>(
                         return Err(err);
                     }
                     Err(OpenUncheckedError::Other(err)) => {
-                        // An error occurred. If this was the last component, record it as the
-                        // last component of the canonical path, even if we couldn't open it.
-                        if components.is_empty() {
+                        // An error occurred. If this was the last component, and the error wasn't
+                        // due to invalid inputs (eg. the path has an embedded NUL), record it as
+                        // the last component of the canonical path, even if we couldn't open it.
+                        if components.is_empty() && err.kind() != io::ErrorKind::InvalidInput {
                             canonical_path.push(&one);
                             canonical_path.complete();
                         }

--- a/tests/issue-22577.rs
+++ b/tests/issue-22577.rs
@@ -1,0 +1,32 @@
+// This test module derived from Rust's src/test/ui/issues/issue-22577.rs
+// at revision 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
+
+// run-pass
+#![allow(dead_code)]
+// pretty-expanded FIXME #23616
+// ignore-cloudabi no std::fs
+
+use cap_std::{fs, net};
+
+fn assert_both<T: Send + Sync>() {}
+fn assert_send<T: Send>() {}
+
+#[test]
+fn issue_22577() {
+    assert_both::<fs::File>();
+    assert_both::<fs::Metadata>();
+    // TODO: Make cap_std's directory types Send and Sync.
+    //assert_both::<fs::ReadDir>();
+    //assert_both::<fs::DirEntry>();
+    assert_both::<fs::OpenOptions>();
+    assert_both::<fs::Permissions>();
+
+    assert_both::<net::TcpStream>();
+    assert_both::<net::TcpListener>();
+    assert_both::<net::UdpSocket>();
+    assert_both::<net::SocketAddr>();
+    assert_both::<net::SocketAddrV4>();
+    assert_both::<net::SocketAddrV6>();
+    assert_both::<net::Ipv4Addr>();
+    assert_both::<net::Ipv6Addr>();
+}

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -1,0 +1,62 @@
+// This test module derived from Rust's src/test/ui/paths-containing-nul.rs
+// at revision 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
+
+// run-pass
+
+#![allow(deprecated)]
+// ignore-cloudabi no files or I/O
+// ignore-wasm32-bare no files or I/O
+// ignore-emscripten no files
+// ignore-sgx no files
+
+mod sys_common;
+
+use std::io;
+use sys_common::io::tmpdir;
+
+fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
+    fn inner(on: &str, result: io::Result<()>) {
+        match result {
+            Ok(()) => panic!("{} didn't return an error on a path with NUL", on),
+            Err(e) => assert!(
+                e.kind() == io::ErrorKind::InvalidInput,
+                "{} returned a strange {:?} on a path with NUL",
+                on,
+                e.kind()
+            ),
+        }
+    }
+    inner(on, result.map(drop))
+}
+
+#[test]
+fn paths_containing_nul() {
+    let tmpdir = tmpdir();
+
+    assert_invalid_input("File::open", tmpdir.open("\0"));
+    assert_invalid_input("File::create", tmpdir.create("\0"));
+    assert_invalid_input("remove_file", tmpdir.remove_file("\0"));
+    assert_invalid_input("metadata", tmpdir.metadata("\0"));
+    assert_invalid_input("symlink_metadata", tmpdir.symlink_metadata("\0"));
+
+    // Create a file inside the sandbox.
+    let dummy_file = "dummy_file";
+    tmpdir.create(dummy_file).expect("creating dummy_file");
+
+    assert_invalid_input("rename1", tmpdir.rename("\0", &tmpdir, "a"));
+    assert_invalid_input("rename2", tmpdir.rename(&dummy_file, &tmpdir, "\0"));
+    assert_invalid_input("copy1", tmpdir.copy("\0", "a"));
+    assert_invalid_input("copy2", tmpdir.copy(&dummy_file, "\0"));
+    assert_invalid_input("hard_link1", tmpdir.hard_link("\0", &tmpdir, "a"));
+    assert_invalid_input("hard_link2", tmpdir.hard_link(&dummy_file, &tmpdir, "\0"));
+    //fixmeassert_invalid_input("soft_link1", tmpdir.soft_link("\0", &tmpdir, "a"));
+    //fixmeassert_invalid_input("soft_link2", tmpdir.soft_link(&dummy_file, &tmpdir, "\0"));
+    assert_invalid_input("read_link", tmpdir.read_link("\0"));
+    assert_invalid_input("canonicalize", tmpdir.canonicalize("\0"));
+    assert_invalid_input("create_dir", tmpdir.create_dir("\0"));
+    assert_invalid_input("create_dir_all", tmpdir.create_dir_all("\0"));
+    assert_invalid_input("remove_dir", tmpdir.remove_dir("\0"));
+    assert_invalid_input("remove_dir_all", tmpdir.remove_dir_all("\0"));
+    assert_invalid_input("read_dir", tmpdir.read_dir("\0"));
+    // `Dir` has no `set_permissions` function.
+}

--- a/tests/rename-directory.rs
+++ b/tests/rename-directory.rs
@@ -1,0 +1,37 @@
+// This test module derived from Rust's src/test/ui-fulldeps/rename-directory.rs
+// at revision 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
+
+// run-pass
+
+#![allow(unused_must_use)]
+#![allow(unused_imports)]
+// This test can't be a unit test in std,
+// because it needs TempDir, which is in extra
+
+// ignore-cross-compile
+
+mod sys_common;
+
+use cap_std::fs::{self, File};
+use std::{
+    env,
+    ffi::CString,
+    path::{Path, PathBuf},
+};
+use sys_common::io::tmpdir;
+
+#[test]
+fn rename_directory() {
+    let tmpdir = tmpdir();
+    let old_path = Path::new("foo/bar/baz");
+    tmpdir.create_dir_all(&old_path).unwrap();
+    let test_file = &old_path.join("temp.txt");
+
+    tmpdir.create(test_file).unwrap();
+
+    let new_path = Path::new("quux/blat");
+    tmpdir.create_dir_all(&new_path).unwrap();
+    tmpdir.rename(&old_path, &tmpdir, &new_path.join("newdir"));
+    assert!(tmpdir.is_dir(new_path.join("newdir")));
+    assert!(tmpdir.exists(new_path.join("newdir/temp.txt")));
+}

--- a/tests/sys_common/mod.rs
+++ b/tests/sys_common/mod.rs
@@ -1,6 +1,7 @@
 #![macro_use]
 pub mod io;
 
+#[allow(unused)]
 macro_rules! check {
     ($e:expr) => {
         match $e {


### PR DESCRIPTION
paths-containing-nul.rs turned up a bug handling embedded NUL
characters; this is now fixed in open_manually.rs.

issue-22577.rs turned up the issue that `cap-std`'s `ReadDir`
and `DirEntry` aren't `Send` and `Sync`. This will likely require a
change to the underlying yanix type. Disable those tests for now.