### PR TITLE
Rewrite URLs in cap-async-std's doc comments.

### DIFF
--- a/cap-async-std/README.md
+++ b/cap-async-std/README.md
@@ -14,8 +14,7 @@ This crate provides a capability-based version of [`async-std`]. It provides all
 interfaces you are used to, but in a capability-based version.
 
 This is a very simplistic port of [`cap-std`] to `async-std`. Key `fs` functions
-including opening files still use synchronous API calls. Quite a few comments still
-talk about `std` rather than `async-std`.
+including opening files still use synchronous API calls.
 
 See the [`cap-std` README.md] for more information about capability-based security.
 

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -56,10 +56,10 @@ impl Dir {
 
     /// Attempts to open a file in read-only mode.
     ///
-    /// This corresponds to [`std::fs::File::open`], but only accesses paths
+    /// This corresponds to [`async_std::fs::File::open`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::File::open`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.open
+    /// [`async_std::fs::File::open`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.open
     #[inline]
     pub fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<File> {
         self.open_with(path, OpenOptions::new().read(true))
@@ -67,12 +67,12 @@ impl Dir {
 
     /// Opens a file at `path` with the options specified by `self`.
     ///
-    /// This corresponds to [`std::fs::OpenOptions::open`].
+    /// This corresponds to [`async_std::fs::OpenOptions::open`].
     ///
     /// Instead of being a method on `OpenOptions`, this is a method on `Dir`,
     /// and it only accesses functions relative to `self`.
     ///
-    /// [`std::fs::OpenOptions::open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
+    /// [`async_std::fs::OpenOptions::open`]: https://docs.rs/async-std/latest/async_std/fs/struct.OpenOptions.html#method.open
     #[inline]
     pub fn open_with<P: AsRef<Path>>(&self, path: P, options: &OpenOptions) -> io::Result<File> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -101,10 +101,10 @@ impl Dir {
 
     /// Creates a new, empty directory at the provided path.
     ///
-    /// This corresponds to [`std::fs::create_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::create_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::create_dir`]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
+    /// [`async_std::fs::create_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.create_dir.html
     #[inline]
     pub fn create_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         self._create_dir_one(path.as_ref(), &DirOptions::new())
@@ -112,10 +112,10 @@ impl Dir {
 
     /// Recursively create a directory and all of its parent components if they are missing.
     ///
-    /// This corresponds to [`std::fs::create_dir_all`], but only accesses paths
+    /// This corresponds to [`async_std::fs::create_dir_all`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::create_dir_all`]: https://doc.rust-lang.org/std/fs/fn.create_dir_all.html
+    /// [`async_std::fs::create_dir_all`]: https://docs.rs/async-std/latest/async_std/fs/fn.create_dir_all.html
     #[inline]
     pub fn create_dir_all<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         self._create_dir_all(path.as_ref(), &DirOptions::new())
@@ -123,9 +123,9 @@ impl Dir {
 
     /// Creates the specified directory with the options configured in this builder.
     ///
-    /// This corresponds to [`std::fs::DirBuilder::create`].
+    /// This corresponds to [`async_std::fs::DirBuilder::create`].
     ///
-    /// [`std::fs::DirBuilder::create`]: https://doc.rust-lang.org/std/fs/struct.DirBuilder.html#method.create
+    /// [`async_std::fs::DirBuilder::create`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirBuilder.html#method.create
     #[inline]
     pub fn create_dir_with<P: AsRef<Path>>(
         &self,
@@ -174,10 +174,10 @@ impl Dir {
 
     /// Opens a file in write-only mode.
     ///
-    /// This corresponds to [`std::fs::File::create`], but only accesses paths
+    /// This corresponds to [`async_std::fs::File::create`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::File::create`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.create
+    /// [`async_std::fs::File::create`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.create
     #[inline]
     pub fn create<P: AsRef<Path>>(&self, path: P) -> io::Result<File> {
         self.open_with(
@@ -189,10 +189,10 @@ impl Dir {
     /// Returns the canonical form of a path with all intermediate components normalized
     /// and symbolic links resolved.
     ///
-    /// This corresponds to [`std::fs::canonicalize`], but instead of returning an
+    /// This corresponds to [`async_std::fs::canonicalize`], but instead of returning an
     /// absolute path, returns a path relative to the directory represented by `self`.
     ///
-    /// [`std::fs::canonicalize`]: https://doc.rust-lang.org/std/fs/fn.canonicalize.html
+    /// [`async_std::fs::canonicalize`]: https://docs.rs/async-std/latest/async_std/fs/fn.canonicalize.html
     #[inline]
     pub fn canonicalize<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -202,10 +202,10 @@ impl Dir {
     /// Copies the contents of one file to another. This function will also copy the permission
     /// bits of the original file to the destination file.
     ///
-    /// This corresponds to [`std::fs::copy`], but only accesses paths
+    /// This corresponds to [`async_std::fs::copy`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
+    /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
     pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to: Q) -> io::Result<u64> {
         // Implementation derived from `copy` in Rust's
@@ -232,10 +232,10 @@ impl Dir {
 
     /// Creates a new hard link on a filesystem.
     ///
-    /// This corresponds to [`std::fs::hard_link`], but only accesses paths
+    /// This corresponds to [`async_std::fs::hard_link`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::hard_link`]: https://doc.rust-lang.org/std/fs/fn.hard_link.html
+    /// [`async_std::fs::hard_link`]: https://docs.rs/async-std/latest/async_std/fs/fn.hard_link.html
     #[inline]
     pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
@@ -250,10 +250,10 @@ impl Dir {
 
     /// Given a path, query the file system to get information about a file, directory, etc.
     ///
-    /// This corresponds to [`std::fs::metadata`], but only accesses paths
+    /// This corresponds to [`async_std::fs::metadata`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::metadata`]: https://doc.rust-lang.org/std/fs/fn.metadata.html
+    /// [`async_std::fs::metadata`]: https://docs.rs/async-std/latest/async_std/fs/fn.metadata.html
     #[inline]
     pub fn metadata<P: AsRef<Path>>(&self, path: P) -> io::Result<Metadata> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -262,10 +262,10 @@ impl Dir {
 
     /// Returns an iterator over the entries within a directory.
     ///
-    /// This corresponds to [`std::fs::read_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_dir`]: https://doc.rust-lang.org/std/fs/fn.read_dir.html
+    /// [`async_std::fs::read_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_dir.html
     #[inline]
     pub fn read_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<ReadDir> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -274,10 +274,10 @@ impl Dir {
 
     /// Read the entire contents of a file into a bytes vector.
     ///
-    /// This corresponds to [`std::fs::read`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read`]: https://doc.rust-lang.org/std/fs/fn.read.html
+    /// [`async_std::fs::read`]: https://docs.rs/async-std/latest/async_std/fs/fn.read.html
     #[inline]
     pub async fn read<P: AsRef<Path>>(&self, path: P) -> io::Result<Vec<u8>> {
         use async_std::prelude::*;
@@ -289,10 +289,10 @@ impl Dir {
 
     /// Reads a symbolic link, returning the file that the link points to.
     ///
-    /// This corresponds to [`std::fs::read_link`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_link`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_link`]: https://doc.rust-lang.org/std/fs/fn.read_link.html
+    /// [`async_std::fs::read_link`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_link.html
     #[inline]
     pub fn read_link<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -301,10 +301,10 @@ impl Dir {
 
     /// Read the entire contents of a file into a string.
     ///
-    /// This corresponds to [`std::fs::read_to_string`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_to_string`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html
+    /// [`async_std::fs::read_to_string`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_to_string.html
     #[inline]
     pub async fn read_to_string<P: AsRef<Path>>(&self, path: P) -> io::Result<String> {
         use async_std::prelude::*;
@@ -315,10 +315,10 @@ impl Dir {
 
     /// Removes an existing, empty directory.
     ///
-    /// This corresponds to [`std::fs::remove_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_dir`]: https://doc.rust-lang.org/std/fs/fn.remove_dir.html
+    /// [`async_std::fs::remove_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_dir.html
     #[inline]
     pub fn remove_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -327,10 +327,10 @@ impl Dir {
 
     /// Removes a directory at this path, after removing all its contents. Use carefully!
     ///
-    /// This corresponds to [`std::fs::remove_dir_all`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_dir_all`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_dir_all`]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
+    /// [`async_std::fs::remove_dir_all`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_dir_all.html
     #[inline]
     pub async fn remove_dir_all<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -339,10 +339,10 @@ impl Dir {
 
     /// Removes a file from a filesystem.
     ///
-    /// This corresponds to [`std::fs::remove_file`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_file`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_file`]: https://doc.rust-lang.org/std/fs/fn.remove_file.html
+    /// [`async_std::fs::remove_file`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_file.html
     #[inline]
     pub fn remove_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -351,10 +351,10 @@ impl Dir {
 
     /// Rename a file or directory to a new name, replacing the original file if to already exists.
     ///
-    /// This corresponds to [`std::fs::rename`], but only accesses paths
+    /// This corresponds to [`async_std::fs::rename`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::rename`]: https://doc.rust-lang.org/std/fs/fn.rename.html
+    /// [`async_std::fs::rename`]: https://docs.rs/async-std/latest/async_std/fs/fn.rename.html
     #[inline]
     pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
@@ -369,10 +369,10 @@ impl Dir {
 
     /// Query the metadata about a file without following symlinks.
     ///
-    /// This corresponds to [`std::fs::symlink_metadata`], but only accesses paths
+    /// This corresponds to [`async_std::fs::symlink_metadata`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::symlink_metadata`]: https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html
+    /// [`async_std::fs::symlink_metadata`]: https://docs.rs/async-std/latest/async_std/fs/fn.symlink_metadata.html
     #[inline]
     pub fn symlink_metadata<P: AsRef<Path>>(&self, path: P) -> io::Result<Metadata> {
         let file = unsafe { as_sync(&self.std_file) };
@@ -381,10 +381,10 @@ impl Dir {
 
     /// Write a slice as the entire contents of a file.
     ///
-    /// This corresponds to [`std::fs::write`], but only accesses paths
+    /// This corresponds to [`async_std::fs::write`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::write`]: https://doc.rust-lang.org/std/fs/fn.write.html
+    /// [`async_std::fs::write`]: https://docs.rs/async-std/latest/async_std/fs/fn.write.html
     #[inline]
     pub async fn write<P: AsRef<Path>, C: AsRef<[u8]>>(
         &self,
@@ -398,10 +398,10 @@ impl Dir {
 
     /// Creates a new symbolic link on a filesystem.
     ///
-    /// This corresponds to [`std::os::unix::fs::symlink`], but only accesses paths
+    /// This corresponds to [`async_std::os::unix::fs::symlink`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
+    /// [`async_std::os::unix::fs::symlink`]: https://docs.rs/async-std/latest/async_std/os/unix/fs/fn.symlink.html
     #[cfg(any(
         unix,
         target_os = "wasi",
@@ -417,10 +417,10 @@ impl Dir {
 
     /// Creates a new file symbolic link on a filesystem.
     ///
-    /// This corresponds to [`std::os::windows::fs::symlink_file`], but only accesses paths
+    /// This corresponds to [`async_std::os::windows::fs::symlink_file`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::windows::fs::symlink_file`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
+    /// [`async_std::os::windows::fs::symlink_file`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_file.html
     #[cfg(windows)]
     #[inline]
     pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> io::Result<()> {
@@ -430,10 +430,10 @@ impl Dir {
 
     /// Creates a new directory symlink on a filesystem.
     ///
-    /// This corresponds to [`std::os::windows::fs::symlink_dir`], but only accesses paths
+    /// This corresponds to [`async_std::os::windows::fs::symlink_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::windows::fs::symlink_dir`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
+    /// [`async_std::os::windows::fs::symlink_dir`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_dir.html
     #[cfg(windows)]
     #[inline]
     pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> io::Result<()> {
@@ -443,12 +443,12 @@ impl Dir {
 
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixListener::bind`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixListener::bind`], but only
     /// accesses paths relative to `self`.
     ///
     /// XXX: This function is not yet implemented.
     ///
-    /// [`std::os::unix::net::UnixListener::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.bind
+    /// [`async_std::os::unix::net::UnixListener::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.bind
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_listener<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixListener> {
@@ -461,12 +461,12 @@ impl Dir {
 
     /// Connects to the socket named by path.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::connect`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::connect`], but only
     /// accesses paths relative to `self`.
     ///
     /// XXX: This function is not yet implemented.
     ///
-    /// [`std::os::unix::net::UnixStream::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.connect
+    /// [`async_std::os::unix::net::UnixStream::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.connect
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_stream<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixStream> {
@@ -479,12 +479,12 @@ impl Dir {
 
     /// Creates a Unix datagram socket bound to the given path.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::bind`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::bind`], but only
     /// accesses paths relative to `self`.
     ///
     /// XXX: This function is not yet implemented.
     ///
-    /// [`std::os::unix::net::UnixDatagram::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.bind
+    /// [`async_std::os::unix::net::UnixDatagram::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.bind
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_datagram<P: AsRef<Path>>(&self, path: P) -> io::Result<UnixDatagram> {
@@ -497,12 +497,12 @@ impl Dir {
 
     /// Connects the socket to the specified address.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::connect`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::connect`], but only
     /// accesses paths relative to `self`.
     ///
     /// XXX: This function is not yet implemented.
     ///
-    /// [`std::os::unix::net::UnixDatagram::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.connect
+    /// [`async_std::os::unix::net::UnixDatagram::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.connect
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_datagram<P: AsRef<Path>>(
@@ -519,12 +519,12 @@ impl Dir {
 
     /// Sends data on the socket to the specified address.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::send_to`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::send_to`], but only
     /// accesses paths relative to `self`.
     ///
     /// XXX: This function is not yet implemented.
     ///
-    /// [`std::os::unix::net::UnixDatagram::send_to`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    /// [`async_std::os::unix::net::UnixDatagram::send_to`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send_to
     #[cfg(unix)]
     #[inline]
     pub fn send_to_unix_datagram_addr<P: AsRef<Path>>(
@@ -545,10 +545,10 @@ impl Dir {
 
     /// Returns `true` if the path points at an existing entity.
     ///
-    /// This corresponds to [`std::path::Path::exists`], but only
+    /// This corresponds to [`async_std::path::Path::exists`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::path::Path::exists`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.exists
+    /// [`async_std::path::Path::exists`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.exists
     #[inline]
     pub fn exists<P: AsRef<Path>>(&self, path: P) -> bool {
         self.metadata(path).is_ok()
@@ -556,10 +556,10 @@ impl Dir {
 
     /// Returns `true` if the path exists on disk and is pointing at a regular file.
     ///
-    /// This corresponds to [`std::path::Path::is_file`], but only
+    /// This corresponds to [`async_std::path::Path::is_file`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::path::Path::is_file`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_file
+    /// [`async_std::path::Path::is_file`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.is_file
     #[inline]
     pub fn is_file<P: AsRef<Path>>(&self, path: P) -> bool {
         self.metadata(path).map(|m| m.is_file()).unwrap_or(false)
@@ -567,11 +567,11 @@ impl Dir {
 
     /// Checks if `path` is a directory.
     ///
-    /// This is similar to [`std::path::Path::is_dir`] in that it checks if `path` relative to `Dir`
+    /// This is similar to [`async_std::path::Path::is_dir`] in that it checks if `path` relative to `Dir`
     /// is a directory. This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links, this will return `false`.
     ///
-    /// [`std::path::Path::is_dir`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_dir
+    /// [`async_std::path::Path::is_dir`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.is_dir
     #[inline]
     pub fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
         self.metadata(path).map(|m| m.is_dir()).unwrap_or(false)

--- a/cap-async-std/src/fs/dir_entry.rs
+++ b/cap-async-std/src/fs/dir_entry.rs
@@ -21,9 +21,9 @@ pub struct DirEntry {
 impl DirEntry {
     /// Returns the metadata for the file that this entry points at.
     ///
-    /// This corresponds to [`std::fs::DirEntry::metadata`].
+    /// This corresponds to [`async_std::fs::DirEntry::metadata`].
     ///
-    /// [`std::fs::DirEntry::metadata`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.metadata
+    /// [`async_std::fs::DirEntry::metadata`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.metadata
     #[inline]
     pub async fn metadata(&self) -> io::Result<Metadata> {
         // TODO: Make this actually async.
@@ -32,9 +32,9 @@ impl DirEntry {
 
     /// Returns the file type for the file that this entry points at.
     ///
-    /// This corresponds to [`std::fs::DirEntry::file_type`].
+    /// This corresponds to [`async_std::fs::DirEntry::file_type`].
     ///
-    /// [`std::fs::DirEntry::file_type`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_type
+    /// [`async_std::fs::DirEntry::file_type`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.file_type
     #[inline]
     pub async fn file_type(&self) -> io::Result<FileType> {
         // TODO: Make this actually async.
@@ -43,9 +43,9 @@ impl DirEntry {
 
     /// Returns the bare file name of this directory entry without any other leading path component.
     ///
-    /// This corresponds to [`std::fs::DirEntry::file_name`].
+    /// This corresponds to [`async_std::fs::DirEntry::file_name`].
     ///
-    /// [`std::fs::DirEntry::file_name`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_name
+    /// [`async_std::fs::DirEntry::file_name`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.file_name
     #[inline]
     pub fn file_name(&self) -> ffi::OsString {
         self.inner.file_name()

--- a/cap-async-std/src/fs/file.rs
+++ b/cap-async-std/src/fs/file.rs
@@ -13,13 +13,13 @@ use std::{fmt, pin::Pin};
 
 /// A reference to an open file on a filesystem.
 ///
-/// This corresponds to [`std::fs::File`].
+/// This corresponds to [`async_std::fs::File`].
 ///
 /// Note that this `File` has no `open` or `create` methods. To open or create
 /// a file, you must first obtain a [`Dir`] containing the path, and then call
 /// [`Dir::open`] or [`Dir::create`].
 ///
-/// [`std::fs::File`]: https://doc.rust-lang.org/std/fs/struct.File.html
+/// [`async_std::fs::File`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html
 /// [`Dir`]: struct.Dir.html
 /// [`Dir::open`]: struct.Dir.html#method.open
 /// [`Dir::create`]: struct.Dir.html#method.create
@@ -36,9 +36,9 @@ impl File {
 
     /// Attempts to sync all OS-internal metadata to disk.
     ///
-    /// This corresponds to [`std::fs::File::sync_all`].
+    /// This corresponds to [`async_std::fs::File::sync_all`].
     ///
-    /// [`std::fs::File::sync_all`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_all
+    /// [`async_std::fs::File::sync_all`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.sync_all
     #[inline]
     pub async fn sync_all(&self) -> io::Result<()> {
         self.std.sync_all().await
@@ -47,9 +47,9 @@ impl File {
     /// This function is similar to `sync_all`, except that it may not synchronize
     /// file metadata to a filesystem.
     ///
-    /// This corresponds to [`std::fs::File::sync_data`].
+    /// This corresponds to [`async_std::fs::File::sync_data`].
     ///
-    /// [`std::fs::File::sync_data`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_data
+    /// [`async_std::fs::File::sync_data`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.sync_data
     #[inline]
     pub async fn sync_data(&self) -> io::Result<()> {
         self.std.sync_data().await
@@ -58,9 +58,9 @@ impl File {
     /// Truncates or extends the underlying file, updating the size of this file
     /// to become size.
     ///
-    /// This corresponds to [`std::fs::File::set_len`].
+    /// This corresponds to [`async_std::fs::File::set_len`].
     ///
-    /// [`std::fs::File::set_len`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.set_len
+    /// [`async_std::fs::File::set_len`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.set_len
     #[inline]
     pub async fn set_len(&self, size: u64) -> io::Result<()> {
         self.std.set_len(size).await
@@ -68,9 +68,9 @@ impl File {
 
     /// Queries metadata about the underlying file.
     ///
-    /// This corresponds to [`std::fs::File::metadata`].
+    /// This corresponds to [`async_std::fs::File::metadata`].
     ///
-    /// [`std::fs::File::metadata`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.metadata
+    /// [`async_std::fs::File::metadata`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.metadata
     #[inline]
     pub async fn metadata(&self) -> io::Result<Metadata> {
         self.std.metadata().await.map(metadata_from_std)
@@ -80,9 +80,9 @@ impl File {
 
     /// Changes the permissions on the underlying file.
     ///
-    /// This corresponds to [`std::fs::File::set_permissions`].
+    /// This corresponds to [`async_std::fs::File::set_permissions`].
     ///
-    /// [`std::fs::File::set_permissions`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.set_permissions
+    /// [`async_std::fs::File::set_permissions`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.set_permissions
     #[inline]
     pub async fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
         let sync = unsafe { as_sync(&self.std) };

--- a/cap-async-std/src/fs/mod.rs
+++ b/cap-async-std/src/fs/mod.rs
@@ -32,9 +32,9 @@ pub use read_dir::*;
 #[cfg(not(target_os = "wasi"))]
 pub use cap_primitives::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
-// Re-export things from `std` that we can use as-is.
+// Re-export things from `async_std` that we can use as-is.
 #[cfg(target_os = "wasi")]
-pub use std::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
+pub use async_std::fs::{DirBuilder, FileType, Metadata, OpenOptions, Permissions};
 
 /// Utility for returning an `async_std::fs::File` as a `std::fs::File`
 /// for synchronous operations.

--- a/cap-async-std/src/fs/read_dir.rs
+++ b/cap-async-std/src/fs/read_dir.rs
@@ -4,13 +4,13 @@ use std::fmt;
 
 /// Iterator over the entries in a directory.
 ///
-/// This corresponds to [`std::fs::ReadDir`].
+/// This corresponds to [`async_std::fs::ReadDir`].
 ///
 /// Note that there is no `from_std` method, as `async_std::fs::ReadDir` doesn't
 /// provide a way to construct a `ReadDir` without opening directories by
 /// ambient paths.
 ///
-/// [`std::fs::ReadDir`]: https://doc.rust-lang.org/std/fs/struct.ReadDir.html
+/// [`async_std::fs::ReadDir`]: https://docs.rs/async-std/latest/async_std/fs/struct.ReadDir.html
 pub struct ReadDir {
     pub(crate) inner: cap_primitives::fs::ReadDir,
 }

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -48,10 +48,10 @@ impl Dir {
 
     /// Attempts to open a file in read-only mode.
     ///
-    /// This corresponds to [`std::fs::File::open`], but only accesses paths
+    /// This corresponds to [`async_std::fs::File::open`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::File::open`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.open
+    /// [`async_std::fs::File::open`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.open
     #[inline]
     pub fn open<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
@@ -60,12 +60,12 @@ impl Dir {
 
     /// Opens a file at `path` with the options specified by `self`.
     ///
-    /// This corresponds to [`std::fs::OpenOptions::open`].
+    /// This corresponds to [`async_std::fs::OpenOptions::open`].
     ///
     /// Instead of being a method on `OpenOptions`, this is a method on `Dir`,
     /// and it only accesses functions relative to `self`.
     ///
-    /// [`std::fs::OpenOptions::open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
+    /// [`async_std::fs::OpenOptions::open`]: https://docs.rs/async-std/latest/async_std/fs/struct.OpenOptions.html#method.open
     #[inline]
     pub fn open_with<P: AsRef<str>>(&self, path: P, options: &OpenOptions) -> io::Result<File> {
         let path = from_utf8(path)?;
@@ -83,10 +83,10 @@ impl Dir {
 
     /// Creates a new, empty directory at the provided path.
     ///
-    /// This corresponds to [`std::fs::create_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::create_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::create_dir`]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
+    /// [`async_std::fs::create_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.create_dir.html
     #[inline]
     pub fn create_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
@@ -95,10 +95,10 @@ impl Dir {
 
     /// Recursively create a directory and all of its parent components if they are missing.
     ///
-    /// This corresponds to [`std::fs::create_dir_all`], but only accesses paths
+    /// This corresponds to [`async_std::fs::create_dir_all`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::create_dir_all`]: https://doc.rust-lang.org/std/fs/fn.create_dir_all.html
+    /// [`async_std::fs::create_dir_all`]: https://docs.rs/async-std/latest/async_std/fs/fn.create_dir_all.html
     #[inline]
     pub fn create_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
@@ -107,9 +107,9 @@ impl Dir {
 
     /// Creates the specified directory with the options configured in this builder.
     ///
-    /// This corresponds to [`std::fs::DirBuilder::create`].
+    /// This corresponds to [`async_std::fs::DirBuilder::create`].
     ///
-    /// [`std::fs::DirBuilder::create`]: https://doc.rust-lang.org/std/fs/struct.DirBuilder.html#method.create
+    /// [`async_std::fs::DirBuilder::create`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirBuilder.html#method.create
     #[inline]
     pub fn create_dir_with<P: AsRef<str>>(
         &self,
@@ -122,10 +122,10 @@ impl Dir {
 
     /// Opens a file in write-only mode.
     ///
-    /// This corresponds to [`std::fs::File::create`], but only accesses paths
+    /// This corresponds to [`async_std::fs::File::create`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::File::create`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.create
+    /// [`async_std::fs::File::create`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.create
     #[inline]
     pub fn create<P: AsRef<str>>(&self, path: P) -> io::Result<File> {
         let path = from_utf8(path)?;
@@ -135,10 +135,10 @@ impl Dir {
     /// Returns the canonical form of a path with all intermediate components normalized
     /// and symbolic links resolved.
     ///
-    /// This corresponds to [`std::fs::canonicalize`], but instead of returning an
+    /// This corresponds to [`async_std::fs::canonicalize`], but instead of returning an
     /// absolute path, returns a path relative to the directory represented by `self`.
     ///
-    /// [`std::fs::canonicalize`]: https://doc.rust-lang.org/std/fs/fn.canonicalize.html
+    /// [`async_std::fs::canonicalize`]: https://docs.rs/async-std/latest/async_std/fs/fn.canonicalize.html
     #[inline]
     pub fn canonicalize<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
         let path = from_utf8(path)?;
@@ -148,10 +148,10 @@ impl Dir {
     /// Copies the contents of one file to another. This function will also copy the permission
     /// bits of the original file to the destination file.
     ///
-    /// This corresponds to [`std::fs::copy`], but only accesses paths
+    /// This corresponds to [`async_std::fs::copy`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
+    /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
     pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to: Q) -> io::Result<u64> {
         let from = from_utf8(from)?;
@@ -161,10 +161,10 @@ impl Dir {
 
     /// Creates a new hard link on a filesystem.
     ///
-    /// This corresponds to [`std::fs::hard_link`], but only accesses paths
+    /// This corresponds to [`async_std::fs::hard_link`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::hard_link`]: https://doc.rust-lang.org/std/fs/fn.hard_link.html
+    /// [`async_std::fs::hard_link`]: https://docs.rs/async-std/latest/async_std/fs/fn.hard_link.html
     #[inline]
     pub fn hard_link<P: AsRef<str>, Q: AsRef<str>>(
         &self,
@@ -179,10 +179,10 @@ impl Dir {
 
     /// Given a path, query the file system to get information about a file, directory, etc.
     ///
-    /// This corresponds to [`std::fs::metadata`], but only accesses paths
+    /// This corresponds to [`async_std::fs::metadata`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::metadata`]: https://doc.rust-lang.org/std/fs/fn.metadata.html
+    /// [`async_std::fs::metadata`]: https://docs.rs/async-std/latest/async_std/fs/fn.metadata.html
     #[inline]
     pub fn metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
@@ -191,10 +191,10 @@ impl Dir {
 
     /// Returns an iterator over the entries within a directory.
     ///
-    /// This corresponds to [`std::fs::read_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_dir`]: https://doc.rust-lang.org/std/fs/fn.read_dir.html
+    /// [`async_std::fs::read_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_dir.html
     #[inline]
     pub fn read_dir<P: AsRef<str>>(&self, path: P) -> io::Result<ReadDir> {
         let path = from_utf8(path)?;
@@ -203,10 +203,10 @@ impl Dir {
 
     /// Read the entire contents of a file into a bytes vector.
     ///
-    /// This corresponds to [`std::fs::read`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read`]: https://doc.rust-lang.org/std/fs/fn.read.html
+    /// [`async_std::fs::read`]: https://docs.rs/async-std/latest/async_std/fs/fn.read.html
     #[inline]
     pub async fn read<P: AsRef<str>>(&self, path: P) -> io::Result<Vec<u8>> {
         let path = from_utf8(path)?;
@@ -215,10 +215,10 @@ impl Dir {
 
     /// Reads a symbolic link, returning the file that the link points to.
     ///
-    /// This corresponds to [`std::fs::read_link`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_link`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_link`]: https://doc.rust-lang.org/std/fs/fn.read_link.html
+    /// [`async_std::fs::read_link`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_link.html
     #[inline]
     pub fn read_link<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
         let path = from_utf8(path)?;
@@ -227,10 +227,10 @@ impl Dir {
 
     /// Read the entire contents of a file into a string.
     ///
-    /// This corresponds to [`std::fs::read_to_string`], but only accesses paths
+    /// This corresponds to [`async_std::fs::read_to_string`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html
+    /// [`async_std::fs::read_to_string`]: https://docs.rs/async-std/latest/async_std/fs/fn.read_to_string.html
     #[inline]
     pub async fn read_to_string<P: AsRef<str>>(&self, path: P) -> io::Result<String> {
         let path = from_utf8(path)?;
@@ -239,10 +239,10 @@ impl Dir {
 
     /// Removes an existing, empty directory.
     ///
-    /// This corresponds to [`std::fs::remove_dir`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_dir`]: https://doc.rust-lang.org/std/fs/fn.remove_dir.html
+    /// [`async_std::fs::remove_dir`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_dir.html
     #[inline]
     pub fn remove_dir<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
@@ -251,10 +251,10 @@ impl Dir {
 
     /// Removes a directory at this path, after removing all its contents. Use carefully!
     ///
-    /// This corresponds to [`std::fs::remove_dir_all`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_dir_all`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_dir_all`]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
+    /// [`async_std::fs::remove_dir_all`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_dir_all.html
     #[inline]
     pub async fn remove_dir_all<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
@@ -263,10 +263,10 @@ impl Dir {
 
     /// Removes a file from a filesystem.
     ///
-    /// This corresponds to [`std::fs::remove_file`], but only accesses paths
+    /// This corresponds to [`async_std::fs::remove_file`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::remove_file`]: https://doc.rust-lang.org/std/fs/fn.remove_file.html
+    /// [`async_std::fs::remove_file`]: https://docs.rs/async-std/latest/async_std/fs/fn.remove_file.html
     #[inline]
     pub fn remove_file<P: AsRef<str>>(&self, path: P) -> io::Result<()> {
         let path = from_utf8(path)?;
@@ -275,10 +275,10 @@ impl Dir {
 
     /// Rename a file or directory to a new name, replacing the original file if to already exists.
     ///
-    /// This corresponds to [`std::fs::rename`], but only accesses paths
+    /// This corresponds to [`async_std::fs::rename`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::rename`]: https://doc.rust-lang.org/std/fs/fn.rename.html
+    /// [`async_std::fs::rename`]: https://docs.rs/async-std/latest/async_std/fs/fn.rename.html
     #[inline]
     pub fn rename<P: AsRef<str>, Q: AsRef<str>>(
         &self,
@@ -293,10 +293,10 @@ impl Dir {
 
     /// Query the metadata about a file without following symlinks.
     ///
-    /// This corresponds to [`std::fs::symlink_metadata`], but only accesses paths
+    /// This corresponds to [`async_std::fs::symlink_metadata`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::symlink_metadata`]: https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html
+    /// [`async_std::fs::symlink_metadata`]: https://docs.rs/async-std/latest/async_std/fs/fn.symlink_metadata.html
     #[inline]
     pub fn symlink_metadata<P: AsRef<str>>(&self, path: P) -> io::Result<Metadata> {
         let path = from_utf8(path)?;
@@ -305,10 +305,10 @@ impl Dir {
 
     /// Write a slice as the entire contents of a file.
     ///
-    /// This corresponds to [`std::fs::write`], but only accesses paths
+    /// This corresponds to [`async_std::fs::write`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::fs::write`]: https://doc.rust-lang.org/std/fs/fn.write.html
+    /// [`async_std::fs::write`]: https://docs.rs/async-std/latest/async_std/fs/fn.write.html
     #[inline]
     pub async fn write<P: AsRef<str>, C: AsRef<[u8]>>(
         &self,
@@ -321,10 +321,10 @@ impl Dir {
 
     /// Creates a new symbolic link on a filesystem.
     ///
-    /// This corresponds to [`std::os::unix::fs::symlink`], but only accesses paths
+    /// This corresponds to [`async_std::os::unix::fs::symlink`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
+    /// [`async_std::os::unix::fs::symlink`]: https://docs.rs/async-std/latest/async_std/os/unix/fs/fn.symlink.html
     #[cfg(any(
         unix,
         target_os = "wasi",
@@ -341,10 +341,10 @@ impl Dir {
 
     /// Creates a new file symbolic link on a filesystem.
     ///
-    /// This corresponds to [`std::os::windows::fs::symlink_file`], but only accesses paths
+    /// This corresponds to [`async_std::os::windows::fs::symlink_file`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::windows::fs::symlink_file`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
+    /// [`async_std::os::windows::fs::symlink_file`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_file.html
     #[cfg(windows)]
     #[inline]
     pub fn symlink_file<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
@@ -355,10 +355,10 @@ impl Dir {
 
     /// Creates a new directory symlink on a filesystem.
     ///
-    /// This corresponds to [`std::os::windows::fs::symlink_dir`], but only accesses paths
+    /// This corresponds to [`async_std::os::windows::fs::symlink_dir`], but only accesses paths
     /// relative to `self`.
     ///
-    /// [`std::os::windows::fs::symlink_dir`]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
+    /// [`async_std::os::windows::fs::symlink_dir`]: https://docs.rs/async-std/latest/async_std/os/windows/fs/fn.symlink_dir.html
     #[cfg(windows)]
     #[inline]
     pub fn symlink_dir<P: AsRef<str>, Q: AsRef<str>>(&self, src: P, dst: Q) -> io::Result<()> {
@@ -369,10 +369,10 @@ impl Dir {
 
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixListener::bind`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixListener::bind`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::os::unix::net::UnixListener::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.bind
+    /// [`async_std::os::unix::net::UnixListener::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.bind
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_listener<P: AsRef<str>>(&self, path: P) -> io::Result<UnixListener> {
@@ -382,10 +382,10 @@ impl Dir {
 
     /// Connects to the socket named by path.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::connect`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::connect`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::os::unix::net::UnixStream::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.connect
+    /// [`async_std::os::unix::net::UnixStream::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.connect
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_stream<P: AsRef<str>>(&self, path: P) -> io::Result<UnixStream> {
@@ -395,10 +395,10 @@ impl Dir {
 
     /// Creates a Unix datagram socket bound to the given path.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::bind`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::bind`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::os::unix::net::UnixDatagram::bind`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.bind
+    /// [`async_std::os::unix::net::UnixDatagram::bind`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.bind
     #[cfg(unix)]
     #[inline]
     pub fn bind_unix_datagram<P: AsRef<str>>(&self, path: P) -> io::Result<UnixDatagram> {
@@ -408,10 +408,10 @@ impl Dir {
 
     /// Connects the socket to the specified address.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::connect`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::connect`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::os::unix::net::UnixDatagram::connect`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.connect
+    /// [`async_std::os::unix::net::UnixDatagram::connect`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.connect
     #[cfg(unix)]
     #[inline]
     pub fn connect_unix_datagram<P: AsRef<str>>(
@@ -425,10 +425,10 @@ impl Dir {
 
     /// Sends data on the socket to the specified address.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::send_to`], but only
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::send_to`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::os::unix::net::UnixDatagram::send_to`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send_to
+    /// [`async_std::os::unix::net::UnixDatagram::send_to`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send_to
     #[cfg(unix)]
     #[inline]
     pub fn send_to_unix_datagram_addr<P: AsRef<str>>(
@@ -446,10 +446,10 @@ impl Dir {
 
     /// Returns `true` if the path points at an existing entity.
     ///
-    /// This corresponds to [`std::path::Path::exists`], but only
+    /// This corresponds to [`async_std::path::Path::exists`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::path::Path::exists`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.exists
+    /// [`async_std::path::Path::exists`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.exists
     #[inline]
     pub fn exists<P: AsRef<str>>(&self, path: P) -> bool {
         match from_utf8(path) {
@@ -460,10 +460,10 @@ impl Dir {
 
     /// Returns `true` if the path exists on disk and is pointing at a regular file.
     ///
-    /// This corresponds to [`std::path::Path::is_file`], but only
+    /// This corresponds to [`async_std::path::Path::is_file`], but only
     /// accesses paths relative to `self`.
     ///
-    /// [`std::path::Path::is_file`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_file
+    /// [`async_std::path::Path::is_file`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.is_file
     #[inline]
     pub fn is_file<P: AsRef<str>>(&self, path: P) -> bool {
         match from_utf8(path) {
@@ -474,11 +474,11 @@ impl Dir {
 
     /// Checks if `path` is a directory.
     ///
-    /// This is similar to [`std::path::Path::is_dir`] in that it checks if `path` relative to `Dir`
+    /// This is similar to [`async_std::path::Path::is_dir`] in that it checks if `path` relative to `Dir`
     /// is a directory. This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links, this will return `false`.
     ///
-    /// [`std::path::Path::is_dir`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_dir
+    /// [`async_std::path::Path::is_dir`]: https://docs.rs/async-std/latest/async_std/path/struct.Path.html#method.is_dir
     #[inline]
     pub fn is_dir<P: AsRef<str>>(&self, path: P) -> bool {
         match from_utf8(path) {

--- a/cap-async-std/src/fs_utf8/dir_entry.rs
+++ b/cap-async-std/src/fs_utf8/dir_entry.rs
@@ -6,7 +6,7 @@ use std::{fmt, io};
 
 /// Entries returned by the `ReadDir` iterator.
 ///
-/// This corresponds to [`std::fs::DirEntry`].
+/// This corresponds to [`async_std::fs::DirEntry`].
 ///
 /// Unlike `async_std::fs::DirEntry`, this API has no `DirEntry::path`, because
 /// absolute paths don't interoperate well with the capability model.
@@ -15,7 +15,7 @@ use std::{fmt, io};
 /// provide a way to construct a `DirEntry` without opening directories by
 /// ambient paths.
 ///
-/// [`std::fs::DirEntry`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html
+/// [`async_std::fs::DirEntry`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html
 pub struct DirEntry {
     cap_std: crate::fs::DirEntry,
 }
@@ -29,9 +29,9 @@ impl DirEntry {
 
     /// Returns the metadata for the file that this entry points at.
     ///
-    /// This corresponds to [`std::fs::DirEntry::metadata`].
+    /// This corresponds to [`async_std::fs::DirEntry::metadata`].
     ///
-    /// [`std::fs::DirEntry::metadata`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.metadata
+    /// [`async_std::fs::DirEntry::metadata`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.metadata
     #[inline]
     pub async fn metadata(&self) -> io::Result<Metadata> {
         self.cap_std.metadata().await
@@ -39,9 +39,9 @@ impl DirEntry {
 
     /// Returns the file type for the file that this entry points at.
     ///
-    /// This corresponds to [`std::fs::DirEntry::file_type`].
+    /// This corresponds to [`async_std::fs::DirEntry::file_type`].
     ///
-    /// [`std::fs::DirEntry::file_type`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_type
+    /// [`async_std::fs::DirEntry::file_type`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.file_type
     #[inline]
     pub async fn file_type(&self) -> io::Result<FileType> {
         self.cap_std.file_type().await
@@ -49,9 +49,9 @@ impl DirEntry {
 
     /// Returns the bare file name of this directory entry without any other leading path component.
     ///
-    /// This corresponds to [`std::fs::DirEntry::file_name`].
+    /// This corresponds to [`async_std::fs::DirEntry::file_name`].
     ///
-    /// [`std::fs::DirEntry::file_name`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_name
+    /// [`async_std::fs::DirEntry::file_name`]: https://docs.rs/async-std/latest/async_std/fs/struct.DirEntry.html#method.file_name
     #[inline]
     pub fn file_name(&self) -> String {
         // Unwrap because assume that paths coming from the OS don't have embedded NULs.

--- a/cap-async-std/src/fs_utf8/file.rs
+++ b/cap-async-std/src/fs_utf8/file.rs
@@ -11,13 +11,13 @@ use std::{fmt, pin::Pin};
 
 /// A reference to an open file on a filesystem.
 ///
-/// This corresponds to [`std::fs::File`].
+/// This corresponds to [`async_std::fs::File`].
 ///
 /// Note that this `File` has no `open` or `create` methods. To open or create
 /// a file, you must first obtain a [`Dir`] containing the path, and then call
 /// [`Dir::open`] or [`Dir::create`].
 ///
-/// [`std::fs::File`]: https://doc.rust-lang.org/std/fs/struct.File.html
+/// [`async_std::fs::File`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html
 /// [`Dir`]: struct.Dir.html
 /// [`Dir::open`]: struct.Dir.html#method.open
 /// [`Dir::create`]: struct.Dir.html#method.create
@@ -40,9 +40,9 @@ impl File {
 
     /// Attempts to sync all OS-internal metadata to disk.
     ///
-    /// This corresponds to [`std::fs::File::sync_all`].
+    /// This corresponds to [`async_std::fs::File::sync_all`].
     ///
-    /// [`std::fs::File::sync_all`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_all
+    /// [`async_std::fs::File::sync_all`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.sync_all
     #[inline]
     pub async fn sync_all(&self) -> io::Result<()> {
         self.cap_std.sync_all().await
@@ -51,9 +51,9 @@ impl File {
     /// This function is similar to `sync_all`, except that it may not synchronize
     /// file metadata to a filesystem.
     ///
-    /// This corresponds to [`std::fs::File::sync_data`].
+    /// This corresponds to [`async_std::fs::File::sync_data`].
     ///
-    /// [`std::fs::File::sync_data`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_data
+    /// [`async_std::fs::File::sync_data`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.sync_data
     #[inline]
     pub async fn sync_data(&self) -> io::Result<()> {
         self.cap_std.sync_data().await
@@ -62,9 +62,9 @@ impl File {
     /// Truncates or extends the underlying file, updating the size of this file
     /// to become size.
     ///
-    /// This corresponds to [`std::fs::File::set_len`].
+    /// This corresponds to [`async_std::fs::File::set_len`].
     ///
-    /// [`std::fs::File::set_len`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.set_len
+    /// [`async_std::fs::File::set_len`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.set_len
     #[inline]
     pub async fn set_len(&self, size: u64) -> io::Result<()> {
         self.cap_std.set_len(size).await
@@ -72,9 +72,9 @@ impl File {
 
     /// Queries metadata about the underlying file.
     ///
-    /// This corresponds to [`std::fs::File::metadata`].
+    /// This corresponds to [`async_std::fs::File::metadata`].
     ///
-    /// [`std::fs::File::metadata`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.metadata
+    /// [`async_std::fs::File::metadata`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.metadata
     #[inline]
     pub async fn metadata(&self) -> io::Result<Metadata> {
         self.cap_std.metadata().await
@@ -84,9 +84,9 @@ impl File {
 
     /// Changes the permissions on the underlying file.
     ///
-    /// This corresponds to [`std::fs::File::set_permissions`].
+    /// This corresponds to [`async_std::fs::File::set_permissions`].
     ///
-    /// [`std::fs::File::set_permissions`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.set_permissions
+    /// [`async_std::fs::File::set_permissions`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html#method.set_permissions
     #[inline]
     pub async fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
         self.cap_std.set_permissions(perm).await

--- a/cap-async-std/src/fs_utf8/read_dir.rs
+++ b/cap-async-std/src/fs_utf8/read_dir.rs
@@ -3,13 +3,13 @@ use std::{fmt, io};
 
 /// Iterator over the entries in a directory.
 ///
-/// This corresponds to [`std::fs::ReadDir`].
+/// This corresponds to [`async_std::fs::ReadDir`].
 ///
 /// Note that there is no `from_std` method, as `async_std::fs::ReadDir` doesn't
 /// provide a way to construct a `ReadDir` without opening directories by
 /// ambient paths.
 ///
-/// [`std::fs::ReadDir`]: https://doc.rust-lang.org/std/fs/struct.ReadDir.html
+/// [`async_std::fs::ReadDir`]: https://docs.rs/async-std/latest/async_std/fs/struct.ReadDir.html
 pub struct ReadDir {
     cap_std: crate::fs::ReadDir,
 }

--- a/cap-async-std/src/net/incoming.rs
+++ b/cap-async-std/src/net/incoming.rs
@@ -8,9 +8,9 @@ use std::pin::Pin;
 
 /// An iterator that infinitely `accept`s connections on a [`TcpListener`].
 ///
-/// This corresponds to [`std::net::Incoming`].
+/// This corresponds to [`async_std::net::Incoming`].
 ///
-/// [`std::net::Incoming`]: https://doc.rust-lang.org/std/net/struct.Incoming.html
+/// [`async_std::net::Incoming`]: https://docs.rs/async-std/latest/async_std/net/struct.Incoming.html
 /// [`TcpListener`]: struct.TcpListener.html
 pub struct Incoming<'a> {
     std: net::Incoming<'a>,

--- a/cap-async-std/src/net/tcp_listener.rs
+++ b/cap-async-std/src/net/tcp_listener.rs
@@ -7,13 +7,13 @@ use async_std::{io, net};
 
 /// A TCP socket server, listening for connections.
 ///
-/// This corresponds to [`std::net::TcpListener`].
+/// This corresponds to [`async_std::net::TcpListener`].
 ///
 /// Note that this `TcpListener` has no `bind` method. To bind it to a socket
 /// address, you must first obtain a [`Catalog`] permitting the address, and
 /// then call [`Catalog::bind_tcp_listener`].
 ///
-/// [`std::net::TcpListener`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html
+/// [`async_std::net::TcpListener`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpListener.html
 /// [`Catalog`]: struct.Catalog.html
 /// [`Catalog::bind_tcp_listener`]: struct.Catalog.html#method.bind_tcp_listener
 pub struct TcpListener {
@@ -29,9 +29,9 @@ impl TcpListener {
 
     /// Returns the local socket address of this listener.
     ///
-    /// This corresponds to [`std::net::TcpListener::local_addr`].
+    /// This corresponds to [`async_std::net::TcpListener::local_addr`].
     ///
-    /// [`std::net::TcpListener::local_addr`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#method.local_addr
+    /// [`async_std::net::TcpListener::local_addr`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpListener.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -41,9 +41,9 @@ impl TcpListener {
 
     /// Accept a new incoming connection from this listener.
     ///
-    /// This corresponds to [`std::net::TcpListener::accept`].
+    /// This corresponds to [`async_std::net::TcpListener::accept`].
     ///
-    /// [`std::net::TcpListener::accept`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#method.accept
+    /// [`async_std::net::TcpListener::accept`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpListener.html#method.accept
     #[inline]
     pub async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         self.std
@@ -54,9 +54,9 @@ impl TcpListener {
 
     /// Returns an iterator over the connections being received on this listener.
     ///
-    /// This corresponds to [`std::net::TcpListener::incoming`].
+    /// This corresponds to [`async_std::net::TcpListener::incoming`].
     ///
-    /// [`std::net::TcpListener::incoming`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#method.incoming
+    /// [`async_std::net::TcpListener::incoming`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpListener.html#method.incoming
     #[inline]
     pub fn incoming(&self) -> Incoming {
         Incoming::from_std(self.std.incoming())

--- a/cap-async-std/src/net/tcp_stream.rs
+++ b/cap-async-std/src/net/tcp_stream.rs
@@ -11,13 +11,13 @@ use std::pin::Pin;
 
 /// A TCP stream between a local and a remote socket.
 ///
-/// This corresponds to [`std::net::TcpStream`].
+/// This corresponds to [`async_std::net::TcpStream`].
 ///
 /// Note that this `TcpStream` has no `connect` method. To create a `TcpStream`,
 /// you must first obtain a [`Catalog`] permitting the address, and then call
 /// [`Catalog::connect_tcp_stream`].
 ///
-/// [`std::net::TcpStream`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html
+/// [`async_std::net::TcpStream`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html
 /// [`Catalog`]: struct.Catalog.html
 /// [`Catalog::connect_tcp_stream`]: struct.Catalog.html#method.connect_tcp_stream
 pub struct TcpStream {
@@ -33,9 +33,9 @@ impl TcpStream {
 
     /// Returns the local socket address of this listener.
     ///
-    /// This corresponds to [`std::net::TcpStream::local_addr`].
+    /// This corresponds to [`async_std::net::TcpStream::local_addr`].
     ///
-    /// [`std::net::TcpStream::local_addr`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.local_addr
+    /// [`async_std::net::TcpStream::local_addr`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -43,9 +43,9 @@ impl TcpStream {
 
     /// Shuts down the read, write, or both halves of this connection.
     ///
-    /// This corresponds to [`std::net::TcpStream::shutdown`].
+    /// This corresponds to [`async_std::net::TcpStream::shutdown`].
     ///
-    /// [`std::net::TcpStream::shutdown`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.shutdown
+    /// [`async_std::net::TcpStream::shutdown`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.shutdown
     #[inline]
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.std.shutdown(how)
@@ -64,9 +64,9 @@ impl TcpStream {
     /// Receives data on the socket from the remote address to which it is connected, without
     /// removing that data from the queue.
     ///
-    /// This corresponds to [`std::net::TcpStream::peek`].
+    /// This corresponds to [`async_std::net::TcpStream::peek`].
     ///
-    /// [`std::net::TcpStream::peek`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.peek
+    /// [`async_std::net::TcpStream::peek`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.peek
     #[inline]
     pub async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.std.peek(buf).await
@@ -74,9 +74,9 @@ impl TcpStream {
 
     /// Sets the value of the `TCP_NODELAY` option on this socket.
     ///
-    /// This corresponds to [`std::net::TcpStream::set_nodelay`].
+    /// This corresponds to [`async_std::net::TcpStream::set_nodelay`].
     ///
-    /// [`std::net::TcpStream::set_nodelay`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_nodelay
+    /// [`async_std::net::TcpStream::set_nodelay`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.set_nodelay
     #[inline]
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         self.std.set_nodelay(nodelay)
@@ -84,9 +84,9 @@ impl TcpStream {
 
     /// Gets the value of the `TCP_NODELAY` option on this socket.
     ///
-    /// This corresponds to [`std::net::TcpStream::nodelay`].
+    /// This corresponds to [`async_std::net::TcpStream::nodelay`].
     ///
-    /// [`std::net::TcpStream::nodelay`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.nodelay
+    /// [`async_std::net::TcpStream::nodelay`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.nodelay
     #[inline]
     pub fn nodelay(&self) -> io::Result<bool> {
         self.std.nodelay()
@@ -94,9 +94,9 @@ impl TcpStream {
 
     /// Sets the value for the `IP_TTL` option on this socket.
     ///
-    /// This corresponds to [`std::net::TcpStream::set_ttl`].
+    /// This corresponds to [`async_std::net::TcpStream::set_ttl`].
     ///
-    /// [`std::net::TcpStream::set_ttl`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_ttl
+    /// [`async_std::net::TcpStream::set_ttl`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.set_ttl
     #[inline]
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.std.set_ttl(ttl)
@@ -104,9 +104,9 @@ impl TcpStream {
 
     /// Gets the value of the `IP_TTL` option for this socket.
     ///
-    /// This corresponds to [`std::net::TcpStream::ttl`].
+    /// This corresponds to [`async_std::net::TcpStream::ttl`].
     ///
-    /// [`std::net::TcpStream::ttl`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.ttl
+    /// [`async_std::net::TcpStream::ttl`]: https://docs.rs/async-std/latest/async_std/net/struct.TcpStream.html#method.ttl
     #[inline]
     pub fn ttl(&self) -> io::Result<u32> {
         self.std.ttl()

--- a/cap-async-std/src/net/udp_socket.rs
+++ b/cap-async-std/src/net/udp_socket.rs
@@ -7,7 +7,7 @@ use async_std::{io, net};
 
 /// A UDP socket.
 ///
-/// This corresponds to [`std::net::UdpSocket`].
+/// This corresponds to [`async_std::net::UdpSocket`].
 ///
 /// Note that this `UdpSocket` has no `bind`, `connect`, or `send_to` methods. To
 /// create a `UdpSocket` bound to an address or to send a message to an address,
@@ -15,7 +15,7 @@ use async_std::{io, net};
 /// [`Catalog::bind_udp_socket`], or [`Catalog::connect_udp_socket`], or
 /// [`Catalog::send_to_udp_socket_addr`].
 ///
-/// [`std::net::UdpSocket`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html
+/// [`async_std::net::UdpSocket`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html
 /// [`Catalog`]: struct.Catalog.html
 /// [`Catalog::bind_udp_socket`]: struct.Catalog.html#method.bind_udp_socket
 /// [`Catalog::connect_udp_socket`]: struct.Catalog.html#method.connect_udp_socket
@@ -33,9 +33,9 @@ impl UdpSocket {
 
     /// Receives a single datagram message on the socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::recv_from`].
+    /// This corresponds to [`async_std::net::UdpSocket::recv_from`].
     ///
-    /// [`std::net::UdpSocket::recv_from`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.recv_from
+    /// [`async_std::net::UdpSocket::recv_from`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.recv_from
     #[inline]
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.std.recv_from(buf).await
@@ -45,9 +45,9 @@ impl UdpSocket {
 
     /// Returns the socket address of the remote peer this socket was connected to.
     ///
-    /// This corresponds to [`std::net::UdpSocket::peer_addr`].
+    /// This corresponds to [`async_std::net::UdpSocket::peer_addr`].
     ///
-    /// [`std::net::UdpSocket::peer_addr`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.peer_addr
+    /// [`async_std::net::UdpSocket::peer_addr`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.peer_addr
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.std.peer_addr()
@@ -55,9 +55,9 @@ impl UdpSocket {
 
     /// Returns the socket address that this socket was created from.
     ///
-    /// This corresponds to [`std::net::UdpSocket::local_addr`].
+    /// This corresponds to [`async_std::net::UdpSocket::local_addr`].
     ///
-    /// [`std::net::UdpSocket::local_addr`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.local_addr
+    /// [`async_std::net::UdpSocket::local_addr`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -75,9 +75,9 @@ impl UdpSocket {
 
     /// Sets the value of the `SO_BROADCAST` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::set_broadcast`].
+    /// This corresponds to [`async_std::net::UdpSocket::set_broadcast`].
     ///
-    /// [`std::net::UdpSocket::set_broadcast`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_broadcast
+    /// [`async_std::net::UdpSocket::set_broadcast`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.set_broadcast
     #[inline]
     pub fn set_broadcast(&self, broadcast: bool) -> io::Result<()> {
         self.std.set_broadcast(broadcast)
@@ -85,9 +85,9 @@ impl UdpSocket {
 
     /// Gets the value of the `SO_BROADCAST` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::broadcast`].
+    /// This corresponds to [`async_std::net::UdpSocket::broadcast`].
     ///
-    /// [`std::net::UdpSocket::broadcast`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.broadcast
+    /// [`async_std::net::UdpSocket::broadcast`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.broadcast
     #[inline]
     pub fn broadcast(&self) -> io::Result<bool> {
         self.std.broadcast()
@@ -95,9 +95,9 @@ impl UdpSocket {
 
     /// Sets the value of the `IP_MULTICAST_LOOP` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::set_multicast_loop_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::set_multicast_loop_v4`].
     ///
-    /// [`std::net::UdpSocket::set_multicast_loop_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_loop_v4
+    /// [`async_std::net::UdpSocket::set_multicast_loop_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.set_multicast_loop_v4
     #[inline]
     pub fn set_multicast_loop_v4(&self, multicast_loop_v4: bool) -> io::Result<()> {
         self.std.set_multicast_loop_v4(multicast_loop_v4)
@@ -105,9 +105,9 @@ impl UdpSocket {
 
     /// Gets the value of the `IP_MULTICAST_LOOP` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::multicast_loop_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::multicast_loop_v4`].
     ///
-    /// [`std::net::UdpSocket::multicast_loop_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_loop_v4
+    /// [`async_std::net::UdpSocket::multicast_loop_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.multicast_loop_v4
     #[inline]
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
         self.std.multicast_loop_v4()
@@ -115,9 +115,9 @@ impl UdpSocket {
 
     /// Sets the value of the `IP_MULTICAST_TTL` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::set_multicast_ttl_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::set_multicast_ttl_v4`].
     ///
-    /// [`std::net::UdpSocket::set_multicast_ttl_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_ttl_v4
+    /// [`async_std::net::UdpSocket::set_multicast_ttl_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.set_multicast_ttl_v4
     #[inline]
     pub fn set_multicast_ttl_v4(&self, multicast_ttl_v4: u32) -> io::Result<()> {
         self.std.set_multicast_ttl_v4(multicast_ttl_v4)
@@ -125,9 +125,9 @@ impl UdpSocket {
 
     /// Gets the value of the `IP_MULTICAST_TTL` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::multicast_ttl_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::multicast_ttl_v4`].
     ///
-    /// [`std::net::UdpSocket::multicast_ttl_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_ttl_v4
+    /// [`async_std::net::UdpSocket::multicast_ttl_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.multicast_ttl_v4
     #[inline]
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
         self.std.multicast_ttl_v4()
@@ -135,9 +135,9 @@ impl UdpSocket {
 
     /// Sets the value of the `IPV6_MULTICAST_LOOP` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::set_multicast_loop_v6`].
+    /// This corresponds to [`async_std::net::UdpSocket::set_multicast_loop_v6`].
     ///
-    /// [`std::net::UdpSocket::set_multicast_loop_v6`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_multicast_loop_v6
+    /// [`async_std::net::UdpSocket::set_multicast_loop_v6`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.set_multicast_loop_v6
     #[inline]
     pub fn set_multicast_loop_v6(&self, multicast_loop_v6: bool) -> io::Result<()> {
         self.std.set_multicast_loop_v6(multicast_loop_v6)
@@ -145,9 +145,9 @@ impl UdpSocket {
 
     /// Gets the value of the `IPV6_MULTICAST_LOOP` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::multicast_loop_v6`].
+    /// This corresponds to [`async_std::net::UdpSocket::multicast_loop_v6`].
     ///
-    /// [`std::net::UdpSocket::multicast_loop_v6`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.multicast_loop_v6
+    /// [`async_std::net::UdpSocket::multicast_loop_v6`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.multicast_loop_v6
     #[inline]
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
         self.std.multicast_loop_v6()
@@ -155,9 +155,9 @@ impl UdpSocket {
 
     /// Sets the value for the `IP_TTL` option on this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::set_ttl`].
+    /// This corresponds to [`async_std::net::UdpSocket::set_ttl`].
     ///
-    /// [`std::net::UdpSocket::set_ttl`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.set_ttl
+    /// [`async_std::net::UdpSocket::set_ttl`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.set_ttl
     #[inline]
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.std.set_ttl(ttl)
@@ -165,9 +165,9 @@ impl UdpSocket {
 
     /// Gets the value of the `IP_TTL` option for this socket.
     ///
-    /// This corresponds to [`std::net::UdpSocket::ttl`].
+    /// This corresponds to [`async_std::net::UdpSocket::ttl`].
     ///
-    /// [`std::net::UdpSocket::ttl`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.ttl
+    /// [`async_std::net::UdpSocket::ttl`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.ttl
     #[inline]
     pub fn ttl(&self) -> io::Result<u32> {
         self.std.ttl()
@@ -175,9 +175,9 @@ impl UdpSocket {
 
     /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.
     ///
-    /// This corresponds to [`std::net::UdpSocket::join_multicast_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::join_multicast_v4`].
     ///
-    /// [`std::net::UdpSocket::join_multicast_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.join_multicast_v4
+    /// [`async_std::net::UdpSocket::join_multicast_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.join_multicast_v4
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
@@ -186,9 +186,9 @@ impl UdpSocket {
 
     /// Executes an operation of the `IPV6_ADD_MEMBERSHIP` type.
     ///
-    /// This corresponds to [`std::net::UdpSocket::join_multicast_v6`].
+    /// This corresponds to [`async_std::net::UdpSocket::join_multicast_v6`].
     ///
-    /// [`std::net::UdpSocket::join_multicast_v6`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.join_multicast_v6
+    /// [`async_std::net::UdpSocket::join_multicast_v6`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.join_multicast_v6
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
@@ -197,9 +197,9 @@ impl UdpSocket {
 
     /// Executes an operation of the `IP_DROP_MEMBERSHIP` type.
     ///
-    /// This corresponds to [`std::net::UdpSocket::leave_multicast_v4`].
+    /// This corresponds to [`async_std::net::UdpSocket::leave_multicast_v4`].
     ///
-    /// [`std::net::UdpSocket::leave_multicast_v4`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.leave_multicast_v4
+    /// [`async_std::net::UdpSocket::leave_multicast_v4`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.leave_multicast_v4
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
@@ -208,9 +208,9 @@ impl UdpSocket {
 
     /// Executes an operation of the `IPV6_DROP_MEMBERSHIP` type.
     ///
-    /// This corresponds to [`std::net::UdpSocket::leave_multicast_v6`].
+    /// This corresponds to [`async_std::net::UdpSocket::leave_multicast_v6`].
     ///
-    /// [`std::net::UdpSocket::leave_multicast_v6`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.leave_multicast_v6
+    /// [`async_std::net::UdpSocket::leave_multicast_v6`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.leave_multicast_v6
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
@@ -221,9 +221,9 @@ impl UdpSocket {
 
     /// Sends data on the socket to the remote address to which it is connected.
     ///
-    /// This corresponds to [`std::net::UdpSocket::send`].
+    /// This corresponds to [`async_std::net::UdpSocket::send`].
     ///
-    /// [`std::net::UdpSocket::send`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.send
+    /// [`async_std::net::UdpSocket::send`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.send
     #[inline]
     pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
         self.std.send(buf).await
@@ -232,9 +232,9 @@ impl UdpSocket {
     /// Receives a single datagram message on the socket from the remote address to which it is
     /// connected.
     ///
-    /// This corresponds to [`std::net::UdpSocket::recv`].
+    /// This corresponds to [`async_std::net::UdpSocket::recv`].
     ///
-    /// [`std::net::UdpSocket::recv`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.recv
+    /// [`async_std::net::UdpSocket::recv`]: https://docs.rs/async-std/latest/async_std/net/struct.UdpSocket.html#method.recv
     #[inline]
     pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.std.recv(buf).await

--- a/cap-async-std/src/os/unix/net/incoming.rs
+++ b/cap-async-std/src/os/unix/net/incoming.rs
@@ -9,9 +9,9 @@ use std::pin::Pin;
 
 /// An iterator over incoming connections to a [`UnixListener`].
 ///
-/// This corresponds to [`std::os::unix::net::Incoming`].
+/// This corresponds to [`async_std::os::unix::net::Incoming`].
 ///
-/// [`std::os::unix::net::Incoming`]: https://doc.rust-lang.org/std/os/unix/net/struct.Incoming.html
+/// [`async_std::os::unix::net::Incoming`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.Incoming.html
 /// [`UnixListener`]: struct.UnixListener.html
 pub struct Incoming<'a> {
     std: unix::net::Incoming<'a>,

--- a/cap-async-std/src/os/unix/net/mod.rs
+++ b/cap-async-std/src/os/unix/net/mod.rs
@@ -1,8 +1,8 @@
 //! Unix-specific networking functionality
 //!
-//! This corresponds to [`std::os::unix::net`].
+//! This corresponds to [`async_std::os::unix::net`].
 //!
-//! [`std::os::unix::net`]: https://doc.rust-lang.org/std/os/unix/net/
+//! [`async_std::os::unix::net`]: https://docs.rs/async-std/latest/async_std/os/unix/net/
 
 mod incoming;
 mod unix_datagram;

--- a/cap-async-std/src/os/unix/net/unix_datagram.rs
+++ b/cap-async-std/src/os/unix/net/unix_datagram.rs
@@ -9,7 +9,7 @@ use async_std::{
 
 /// A Unix datagram socket.
 ///
-/// This corresponds to [`std::os::unix::net::UnixDatagram`].
+/// This corresponds to [`async_std::os::unix::net::UnixDatagram`].
 ///
 /// Note that this `UnixDatagram` has no `bind`, `connect`, or `send_to`
 /// methods. To create a `UnixDatagram`,
@@ -17,7 +17,7 @@ use async_std::{
 /// [`Dir::bind_unix_datagram`], [`Dir::connect_unix_datagram`], or
 /// [`Dir::send_to_unix_datagram_addr`].
 ///
-/// [`std::os::unix::net::UnixDatagram`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html
+/// [`async_std::os::unix::net::UnixDatagram`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html
 /// [`Dir`]: struct.Dir.html
 /// [`Dir::connect_unix_datagram`]: struct.Dir.html#method.connect_unix_datagram
 /// [`Dir::bind_unix_datagram`]: struct.Dir.html#method.bind_unix_datagram
@@ -35,11 +35,11 @@ impl UnixDatagram {
 
     /// Creates a Unix Datagram socket which is not bound to any address.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::unbound`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::unbound`].
     ///
     /// TODO: should this require a capability?
     ///
-    /// [`std::os::unix::net::UnixDatagram::unbound`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.unbound
+    /// [`async_std::os::unix::net::UnixDatagram::unbound`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.unbound
     #[inline]
     pub fn unbound() -> io::Result<Self> {
         unix::net::UnixDatagram::unbound().map(Self::from_std)
@@ -47,11 +47,11 @@ impl UnixDatagram {
 
     /// Creates an unnamed pair of connected sockets.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::pair`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::pair`].
     ///
     /// TODO: should this require a capability?
     ///
-    /// [`std::os::unix::net::UnixDatagram::pair`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.pair
+    /// [`async_std::os::unix::net::UnixDatagram::pair`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
         unix::net::UnixDatagram::pair().map(|(a, b)| (Self::from_std(a), Self::from_std(b)))
@@ -61,9 +61,9 @@ impl UnixDatagram {
 
     /// Returns the address of this socket.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::local_addr`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::local_addr`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::local_addr`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.local_addr
+    /// [`async_std::os::unix::net::UnixDatagram::local_addr`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -71,9 +71,9 @@ impl UnixDatagram {
 
     /// Returns the address of this socket's peer.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::peer_addr`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::peer_addr`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::peer_addr`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.peer_addr
+    /// [`async_std::os::unix::net::UnixDatagram::peer_addr`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.peer_addr
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.std.peer_addr()
@@ -81,9 +81,9 @@ impl UnixDatagram {
 
     /// Receives data from the socket.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::recv_from`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::recv_from`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::recv_from`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.recv_from
+    /// [`async_std::os::unix::net::UnixDatagram::recv_from`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.recv_from
     #[inline]
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.std.recv_from(buf).await
@@ -91,9 +91,9 @@ impl UnixDatagram {
 
     /// Receives data from the socket.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::recv`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::recv`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::recv`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.recv
+    /// [`async_std::os::unix::net::UnixDatagram::recv`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.recv
     #[inline]
     pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.std.recv(buf).await
@@ -101,9 +101,9 @@ impl UnixDatagram {
 
     /// Sends data on the socket to the socket's peer.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::send`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::send`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::send`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.send
+    /// [`async_std::os::unix::net::UnixDatagram::send`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.send
     #[inline]
     pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
         self.std.send(buf).await
@@ -123,9 +123,9 @@ impl UnixDatagram {
 
     /// Shut down the read, write, or both halves of this connection.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixDatagram::shutdown`].
+    /// This corresponds to [`async_std::os::unix::net::UnixDatagram::shutdown`].
     ///
-    /// [`std::os::unix::net::UnixDatagram::shutdown`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html#method.shutdown
+    /// [`async_std::os::unix::net::UnixDatagram::shutdown`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixDatagram.html#method.shutdown
     #[inline]
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.std.shutdown(how)

--- a/cap-async-std/src/os/unix/net/unix_listener.rs
+++ b/cap-async-std/src/os/unix/net/unix_listener.rs
@@ -9,13 +9,13 @@ use async_std::{
 
 /// A structure representing a Unix domain socket server.
 ///
-/// This corresponds to [`std::os::unix::net::UnixListener`].
+/// This corresponds to [`async_std::os::unix::net::UnixListener`].
 ///
 /// Note that this `UnixListener` has no `bind` method. To bind it to a socket
 /// address, you must first obtain a [`Dir`] containing the path, and
 /// then call [`Dir::bind_unix_listener`].
 ///
-/// [`std::os::unix::net::UnixListener`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html
+/// [`async_std::os::unix::net::UnixListener`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html
 /// [`Dir`]: struct.Dir.html
 /// [`Dir::bind_unix_listener`]: struct.Dir.html#method.bind_unix_listener
 pub struct UnixListener {
@@ -31,9 +31,9 @@ impl UnixListener {
 
     /// Accepts a new incoming connection to this listener.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixListener::accept`].
+    /// This corresponds to [`async_std::os::unix::net::UnixListener::accept`].
     ///
-    /// [`std::os::unix::net::UnixListener::accept`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.accept
+    /// [`async_std::os::unix::net::UnixListener::accept`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.accept
     #[inline]
     pub async fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         self.std
@@ -46,9 +46,9 @@ impl UnixListener {
 
     /// Returns the local socket address of this listener.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixListener::local_addr`].
+    /// This corresponds to [`async_std::os::unix::net::UnixListener::local_addr`].
     ///
-    /// [`std::os::unix::net::UnixListener::local_addr`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.local_addr
+    /// [`async_std::os::unix::net::UnixListener::local_addr`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -60,9 +60,9 @@ impl UnixListener {
 
     /// Returns an iterator over incoming connections.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixListener::incoming`].
+    /// This corresponds to [`async_std::os::unix::net::UnixListener::incoming`].
     ///
-    /// [`std::os::unix::net::UnixListener::incoming`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixListener.html#method.incoming
+    /// [`async_std::os::unix::net::UnixListener::incoming`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixListener.html#method.incoming
     #[inline]
     pub fn incoming(&self) -> Incoming {
         Incoming::from_std(self.std.incoming())

--- a/cap-async-std/src/os/unix/net/unix_stream.rs
+++ b/cap-async-std/src/os/unix/net/unix_stream.rs
@@ -11,13 +11,13 @@ use std::pin::Pin;
 
 /// A Unix stream socket.
 ///
-/// This corresponds to [`std::os::unix::net::UnixStream`].
+/// This corresponds to [`async_std::os::unix::net::UnixStream`].
 ///
 /// Note that this `UnixStream` has no `connect` method. To create a `UnixStream`,
 /// you must first obtain a [`Dir`] containing the path, and then call
 /// [`Dir::connect_unix_stream`].
 ///
-/// [`std::os::unix::net::UnixStream`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html
+/// [`async_std::os::unix::net::UnixStream`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html
 /// [`Dir`]: struct.Dir.html
 /// [`Dir::connect_unix_stream`]: struct.Dir.html#method.connect_unix_stream
 pub struct UnixStream {
@@ -33,11 +33,11 @@ impl UnixStream {
 
     /// Creates an unnamed pair of connected sockets.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::pair`].
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::pair`].
     ///
     /// TODO: should this require a capability?
     ///
-    /// [`std::os::unix::net::UnixStream::pair`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.pair
+    /// [`async_std::os::unix::net::UnixStream::pair`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.pair
     #[inline]
     pub fn pair() -> io::Result<(Self, Self)> {
         unix::net::UnixStream::pair().map(|(a, b)| (Self::from_std(a), Self::from_std(b)))
@@ -47,9 +47,9 @@ impl UnixStream {
 
     /// Returns the socket address of the local half of this connection.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::local_addr`].
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::local_addr`].
     ///
-    /// [`std::os::unix::net::UnixStream::local_addr`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.local_addr
+    /// [`async_std::os::unix::net::UnixStream::local_addr`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.local_addr
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.std.local_addr()
@@ -57,9 +57,9 @@ impl UnixStream {
 
     /// Returns the socket address of the remote half of this connection.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::peer_addr`].
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::peer_addr`].
     ///
-    /// [`std::os::unix::net::UnixStream::peer_addr`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.peer_addr
+    /// [`async_std::os::unix::net::UnixStream::peer_addr`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.peer_addr
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.std.peer_addr()
@@ -79,9 +79,9 @@ impl UnixStream {
 
     /// Shuts down the read, write, or both halves of this connection.
     ///
-    /// This corresponds to [`std::os::unix::net::UnixStream::shutdown`].
+    /// This corresponds to [`async_std::os::unix::net::UnixStream::shutdown`].
     ///
-    /// [`std::os::unix::net::UnixStream::shutdown`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.shutdown
+    /// [`async_std::os::unix::net::UnixStream::shutdown`]: https://docs.rs/async-std/latest/async_std/os/unix/net/struct.UnixStream.html#method.shutdown
     #[inline]
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.std.shutdown(how)


### PR DESCRIPTION
Point to `async-std` on `docs.rs` rather than `std` on `doc.rust-lang.org`.