### PR TITLE
Add some `cargo bench` benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,15 @@ To run the `cap-primitives` fuzzer, run:
 cargo +nightly fuzz run cap-primitives
 ```
 
+## Benchmarking
+
+There are several micro-benchmarks for the `cap-std` crate which stress-test
+specific API features. As micro-benchmarks, they aren't representative of
+real-world use, but they are useful for development of `cap-std`.
+
+To run the `cap-std` benchmarks, run:
+
+```
+cargo +nightly bench
+```
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ yanix = "0.19.0"
 rand = "0.7.3"
 cap-tempfile = { path = "cap-tempfile", version = "0.0.0" }
 cap-directories = { path = "cap-directories", version = "0.0.0" }
+tempfile = "3.1.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 libc = "0.2.72"

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -246,7 +246,7 @@ fn symlink_chasing_open(b: &mut test::Bencher) {
 
     let name = "32";
     b.iter(|| {
-         let _file = dir.open(name).unwrap();
+        let _file = dir.open(name).unwrap();
     });
 }
 
@@ -259,12 +259,16 @@ fn symlink_chasing_open_baseline(b: &mut test::Bencher) {
 
     fs::File::create(dir.path().join("0")).unwrap();
     for i in 0..32 {
-        symlink(dir.path().join(i.to_string()), dir.path().join((i + 1).to_string())).unwrap();
+        symlink(
+            dir.path().join(i.to_string()),
+            dir.path().join((i + 1).to_string()),
+        )
+        .unwrap();
     }
 
     let name = dir.path().join("32");
     b.iter(|| {
-         let _file = fs::File::open(&name).unwrap();
+        let _file = fs::File::open(&name).unwrap();
     });
 }
 
@@ -280,7 +284,7 @@ fn symlink_chasing_metadata(b: &mut test::Bencher) {
 
     let name = "32";
     b.iter(|| {
-         let _metadata = dir.metadata(name).unwrap();
+        let _metadata = dir.metadata(name).unwrap();
     });
 }
 
@@ -293,12 +297,16 @@ fn symlink_chasing_metadata_baseline(b: &mut test::Bencher) {
 
     fs::File::create(dir.path().join("0")).unwrap();
     for i in 0..32 {
-        symlink(dir.path().join(i.to_string()), dir.path().join((i + 1).to_string())).unwrap();
+        symlink(
+            dir.path().join(i.to_string()),
+            dir.path().join((i + 1).to_string()),
+        )
+        .unwrap();
     }
 
     let name = dir.path().join("32");
     b.iter(|| {
-         let _metadata = fs::metadata(&name).unwrap();
+        let _metadata = fs::metadata(&name).unwrap();
     });
 }
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -202,6 +202,7 @@ fn directory_iteration(b: &mut test::Bencher) {
     });
 }
 
+/* TODO: This depends on https://github.com/sunfishcode/cap-std/pull/72
 #[bench]
 fn directory_iteration_fast(b: &mut test::Bencher) {
     let dir = cap_tempfile::tempdir().unwrap();
@@ -216,6 +217,7 @@ fn directory_iteration_fast(b: &mut test::Bencher) {
         }
     });
 }
+*/
 
 #[bench]
 fn directory_iteration_baseline(b: &mut test::Bencher) {

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,0 +1,404 @@
+//! Microbenchmarks for `cap_std`. These have pathological behavior and are
+//! not representative of typical real-world use cases.
+
+#![feature(test)]
+
+extern crate cap_tempfile;
+extern crate tempfile;
+extern crate test;
+
+use std::{fs, path::PathBuf};
+
+#[bench]
+fn nested_directories_open(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    dir.create_dir_all(&path).unwrap();
+
+    b.iter(|| {
+        let _file = dir.open(&path).unwrap();
+    });
+}
+
+#[bench]
+fn nested_directories_open_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    fs::create_dir_all(dir.path().join(&path)).unwrap();
+
+    b.iter(|| {
+        let _file = fs::File::open(dir.path().join(&path)).unwrap();
+    });
+}
+
+#[bench]
+fn nested_directories_metadata(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    dir.create_dir_all(&path).unwrap();
+
+    b.iter(|| {
+        let _metadata = dir.metadata(&path).unwrap();
+    });
+}
+
+#[bench]
+fn nested_directories_metadata_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    path.push(dir);
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    fs::create_dir_all(&path).unwrap();
+
+    b.iter(|| {
+        let _metadata = fs::metadata(&path).unwrap();
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn nested_directories_readlink(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    dir.create_dir_all(&path).unwrap();
+
+    path.push("symlink");
+    dir.symlink("source", &path).unwrap();
+
+    b.iter(|| {
+        let _destination = dir.read_link(&path).unwrap();
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn nested_directories_readlink_baseline(b: &mut test::Bencher) {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    path.push(dir);
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    fs::create_dir_all(&path).unwrap();
+
+    path.push("symlink");
+    symlink("source", &path).unwrap();
+
+    b.iter(|| {
+        let _destination = fs::read_link(&path).unwrap();
+    });
+}
+
+#[bench]
+fn curdir(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push(".");
+    }
+    path.push("def");
+    dir.create("def").unwrap();
+
+    b.iter(|| {
+        let _file = dir.open(&path).unwrap();
+    });
+}
+
+#[bench]
+fn curdir_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    path.push(&dir);
+    for _ in 0..256 {
+        path.push(".");
+    }
+    path.push("def");
+    fs::File::create(dir.path().join("def")).unwrap();
+
+    b.iter(|| {
+        let _file = fs::File::open(&path).unwrap();
+    });
+}
+
+#[bench]
+fn parentdir(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    dir.create_dir_all(&path).unwrap();
+
+    for _ in 0..256 {
+        path.push("..");
+    }
+    path.push("def");
+    dir.create("def").unwrap();
+
+    b.iter(|| {
+        let _file = dir.open(&path).unwrap();
+    });
+}
+
+#[bench]
+fn parentdir_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    path.push(&dir);
+    for _ in 0..256 {
+        path.push("abc");
+    }
+    fs::create_dir_all(&path).unwrap();
+
+    for _ in 0..256 {
+        path.push("..");
+    }
+    path.push("def");
+    fs::File::create(dir.path().join("def")).unwrap();
+
+    b.iter(|| {
+        let _file = fs::File::open(&path).unwrap();
+    });
+}
+
+#[bench]
+fn directory_iteration(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    for i in 0..256 {
+        dir.create(i.to_string()).unwrap();
+    }
+
+    b.iter(|| {
+        for entry in dir.entries().unwrap() {
+            let _file = dir.open(entry.unwrap().file_name()).unwrap();
+        }
+    });
+}
+
+#[bench]
+fn directory_iteration_fast(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    for i in 0..256 {
+        dir.create(i.to_string()).unwrap();
+    }
+
+    b.iter(|| {
+        for entry in dir.entries().unwrap() {
+            let _file = entry.unwrap().open().unwrap();
+        }
+    });
+}
+
+#[bench]
+fn directory_iteration_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    for i in 0..256 {
+        fs::File::create(dir.path().join(i.to_string())).unwrap();
+    }
+
+    b.iter(|| {
+        for entry in fs::read_dir(&dir).unwrap() {
+            let _file = fs::File::open(dir.path().join(entry.unwrap().file_name())).unwrap();
+        }
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn symlink_chasing_open(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    dir.create("0").unwrap();
+    for i in 0..32 {
+        dir.symlink(i.to_string(), (i + 1).to_string()).unwrap();
+    }
+
+    let name = "32";
+    b.iter(|| {
+         let _file = dir.open(name).unwrap();
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn symlink_chasing_open_baseline(b: &mut test::Bencher) {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    fs::File::create(dir.path().join("0")).unwrap();
+    for i in 0..32 {
+        symlink(dir.path().join(i.to_string()), dir.path().join((i + 1).to_string())).unwrap();
+    }
+
+    let name = dir.path().join("32");
+    b.iter(|| {
+         let _file = fs::File::open(&name).unwrap();
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn symlink_chasing_metadata(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    dir.create("0").unwrap();
+    for i in 0..32 {
+        dir.symlink(i.to_string(), (i + 1).to_string()).unwrap();
+    }
+
+    let name = "32";
+    b.iter(|| {
+         let _metadata = dir.metadata(name).unwrap();
+    });
+}
+
+#[cfg(unix)]
+#[bench]
+fn symlink_chasing_metadata_baseline(b: &mut test::Bencher) {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    fs::File::create(dir.path().join("0")).unwrap();
+    for i in 0..32 {
+        symlink(dir.path().join(i.to_string()), dir.path().join((i + 1).to_string())).unwrap();
+    }
+
+    let name = dir.path().join("32");
+    b.iter(|| {
+         let _metadata = fs::metadata(&name).unwrap();
+    });
+}
+
+#[bench]
+fn recursive_create_delete(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    for _ in 0..256 {
+        path.push("abc");
+    }
+
+    b.iter(|| {
+        dir.create_dir_all(&path).unwrap();
+        dir.remove_dir_all(&path).unwrap();
+    });
+}
+
+#[bench]
+fn recursive_create_delete_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut path = PathBuf::new();
+    path.push(dir);
+    for _ in 0..256 {
+        path.push("abc");
+    }
+
+    b.iter(|| {
+        fs::create_dir_all(&path).unwrap();
+        fs::remove_dir_all(&path).unwrap();
+    });
+}
+
+#[bench]
+fn copy_4b(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    dir.write("file", &vec![1u8; 0x4]).unwrap();
+
+    b.iter(|| {
+        dir.copy("file", &dir, "copy").unwrap();
+    });
+}
+
+#[bench]
+fn copy_4b_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let file = dir.path().join("file");
+    let copy = dir.path().join("copy");
+    fs::write(&file, &vec![1u8; 0x4]).unwrap();
+
+    b.iter(|| {
+        fs::copy(&file, &copy).unwrap();
+    });
+}
+
+#[bench]
+fn copy_4k(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    dir.write("file", &vec![1u8; 0x1000]).unwrap();
+
+    b.iter(|| {
+        dir.copy("file", &dir, "copy").unwrap();
+    });
+}
+
+#[bench]
+fn copy_4k_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let file = dir.path().join("file");
+    let copy = dir.path().join("copy");
+    fs::write(&file, &vec![1u8; 0x1000]).unwrap();
+
+    b.iter(|| {
+        fs::copy(&file, &copy).unwrap();
+    });
+}
+
+#[bench]
+fn copy_4m(b: &mut test::Bencher) {
+    let dir = cap_tempfile::tempdir().unwrap();
+
+    dir.write("file", &vec![1u8; 0x400000]).unwrap();
+
+    b.iter(|| {
+        dir.copy("file", &dir, "copy").unwrap();
+    });
+}
+
+#[bench]
+fn copy_4m_baseline(b: &mut test::Bencher) {
+    let dir = tempfile::tempdir().unwrap();
+
+    let file = dir.path().join("file");
+    let copy = dir.path().join("copy");
+    fs::write(&file, &vec![1u8; 0x400000]).unwrap();
+
+    b.iter(|| {
+        fs::copy(&file, &copy).unwrap();
+    });
+}

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -206,7 +206,12 @@ impl Dir {
     ///
     /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
-    pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
+    pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(
+        &self,
+        from: P,
+        to_dir: &Self,
+        to: Q,
+    ) -> io::Result<u64> {
         // Implementation derived from `copy` in Rust's
         // src/libstd/sys_common/fs.rs at revision
         // 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.

--- a/cap-async-std/src/fs/dir.rs
+++ b/cap-async-std/src/fs/dir.rs
@@ -206,7 +206,7 @@ impl Dir {
     ///
     /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
-    pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to: Q) -> io::Result<u64> {
+    pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
         // Implementation derived from `copy` in Rust's
         // src/libstd/sys_common/fs.rs at revision
         // 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
@@ -221,7 +221,7 @@ impl Dir {
         }
 
         let mut reader = self.open(from)?;
-        let mut writer = self.create(to.as_ref())?;
+        let mut writer = to_dir.create(to.as_ref())?;
         let perm = reader.metadata().await?.permissions();
 
         let ret = io::copy(&mut reader, &mut writer).await?;

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -149,7 +149,12 @@ impl Dir {
     ///
     /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
-    pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
+    pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(
+        &self,
+        from: P,
+        to_dir: &Self,
+        to: Q,
+    ) -> io::Result<u64> {
         let from = from_utf8(from)?;
         let to = from_utf8(to)?;
         self.cap_std.copy(from, &to_dir.cap_std, to).await

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -149,10 +149,10 @@ impl Dir {
     ///
     /// [`async_std::fs::copy`]: https://docs.rs/async-std/latest/async_std/fs/fn.copy.html
     #[inline]
-    pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to: Q) -> io::Result<u64> {
+    pub async fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
         let from = from_utf8(from)?;
         let to = from_utf8(to)?;
-        self.cap_std.copy(from, to).await
+        self.cap_std.copy(from, &to_dir.cap_std, to).await
     }
 
     /// Creates a new hard link on a filesystem.

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -199,7 +199,12 @@ impl Dir {
     ///
     /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
     #[inline]
-    pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
+    pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(
+        &self,
+        from: P,
+        to_dir: &Self,
+        to: Q,
+    ) -> io::Result<u64> {
         // Implementation derived from `copy` in Rust's
         // src/libstd/sys_common/fs.rs at revision
         // 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.

--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -199,7 +199,7 @@ impl Dir {
     ///
     /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
     #[inline]
-    pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to: Q) -> io::Result<u64> {
+    pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
         // Implementation derived from `copy` in Rust's
         // src/libstd/sys_common/fs.rs at revision
         // 7e11379f3b4c376fbb9a6c4d44f3286ccc28d149.
@@ -214,7 +214,7 @@ impl Dir {
         }
 
         let mut reader = self.open(from)?;
-        let mut writer = self.create(to.as_ref())?;
+        let mut writer = to_dir.create(to.as_ref())?;
         let perm = reader.metadata()?.permissions();
 
         let ret = io::copy(&mut reader, &mut writer)?;

--- a/src/fs_utf8/dir.rs
+++ b/src/fs_utf8/dir.rs
@@ -148,7 +148,12 @@ impl Dir {
     ///
     /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
     #[inline]
-    pub fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
+    pub fn copy<P: AsRef<str>, Q: AsRef<str>>(
+        &self,
+        from: P,
+        to_dir: &Self,
+        to: Q,
+    ) -> io::Result<u64> {
         let from = from_utf8(from)?;
         let to = from_utf8(to)?;
         self.cap_std.copy(from, &to_dir.cap_std, to)

--- a/src/fs_utf8/dir.rs
+++ b/src/fs_utf8/dir.rs
@@ -148,10 +148,10 @@ impl Dir {
     ///
     /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
     #[inline]
-    pub fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to: Q) -> io::Result<u64> {
+    pub fn copy<P: AsRef<str>, Q: AsRef<str>>(&self, from: P, to_dir: &Self, to: Q) -> io::Result<u64> {
         let from = from_utf8(from)?;
         let to = from_utf8(to)?;
-        self.cap_std.copy(from, to)
+        self.cap_std.copy(from, &to_dir.cap_std, to)
     }
 
     /// Creates a new hard link on a filesystem.

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -47,8 +47,8 @@ fn paths_containing_nul() {
 
     assert_invalid_input("rename1", tmpdir.rename("\0", &tmpdir, "a"));
     assert_invalid_input("rename2", tmpdir.rename(&dummy_file, &tmpdir, "\0"));
-    assert_invalid_input("copy1", tmpdir.copy("\0", "a"));
-    assert_invalid_input("copy2", tmpdir.copy(&dummy_file, "\0"));
+    assert_invalid_input("copy1", tmpdir.copy("\0", &tmpdir, "a"));
+    assert_invalid_input("copy2", tmpdir.copy(&dummy_file, &tmpdir, "\0"));
     assert_invalid_input("hard_link1", tmpdir.hard_link("\0", &tmpdir, "a"));
     assert_invalid_input("hard_link2", tmpdir.hard_link(&dummy_file, &tmpdir, "\0"));
     //fixmeassert_invalid_input("soft_link1", tmpdir.soft_link("\0", &tmpdir, "a"));


### PR DESCRIPTION
As micro-benchmarks, these don't represent real-world usage, but they do show some things of interest to `cap-std` development. `openat2` helps a lot, and #49 and #51 seem to be represented.