### PR TITLE
Add support for Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+# Implementation derived from `.cirrus.yml` in Rust's libc bindings
+# at revision 7f4774e76bd5cb9ccb7140d71ef9be9c16009cdf.
+
+task:
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - cargo test --no-default-features --features=fs_utf8 --all
+    - cargo fuzz build --dev --no-default-features

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,4 @@ task:
     - rustup default stable
   test_script:
     - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
     - cargo test --no-default-features --features=fs_utf8 --all
-    - cargo fuzz build --dev --no-default-features


### PR DESCRIPTION
This adds basic support for Cirrus CI, testing just FreeBSD for now.