### PR TITLE
Simplify `ReadDirInner::next` with more clever use of `Arc`.

### DIFF
--- a/cap-primitives/src/yanix/fs/read_dir_inner.rs
+++ b/cap-primitives/src/yanix/fs/read_dir_inner.rs
@@ -38,11 +38,8 @@ impl Iterator for ReadDirInner {
     type Item = io::Result<DirEntryInner>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: Could we avoid this `clone` by adjusting yanix's API?
-        let mut iter = DirIter::new(Arc::clone(&self.yanix));
-        let clone = Arc::clone(&self.yanix);
         loop {
-            let entry = match iter.next()? {
+            let entry = match DirIter::new(&*self.yanix).next()? {
                 Err(e) => return Some(Err(e)),
                 Ok(entry) => entry,
             };
@@ -50,6 +47,7 @@ impl Iterator for ReadDirInner {
             if file_name != Component::CurDir.as_os_str().as_bytes()
                 && file_name != Component::ParentDir.as_os_str().as_bytes()
             {
+                let clone = Arc::clone(&self.yanix);
                 return Some(Ok(DirEntryInner {
                     yanix: entry,
                     read_dir: Self { yanix: clone },


### PR DESCRIPTION
We may still want to refactor yanix's API here, but for now this change
is enough to eliminate the extra `Arc::clone`, making it more readable.