### PR TITLE
Add enough Win to enable CI testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, macos] #, windows]
+        build: [stable, beta, nightly, macos, windows]
         include:
           - build: stable
             os: ubuntu-latest
@@ -79,9 +79,9 @@ jobs:
           # - build: windows
           #   os: windows-latest
           #   rust: stable
-          # - build: windows
-          #   os: windows-latest
-          #   rust: nightly
+          - build: windows
+            os: windows-latest
+            rust: nightly
 
     steps:
     - uses: actions/checkout@v1

--- a/cap-primitives/src/fs/errors.rs
+++ b/cap-primitives/src/fs/errors.rs
@@ -1,0 +1,11 @@
+use std::io;
+
+pub(crate) use super::errors_impl::*;
+
+#[cold]
+pub(crate) fn escape_attempt() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "a path led outside of the filesystem",
+    )
+}

--- a/cap-primitives/src/fs/errors.rs
+++ b/cap-primitives/src/fs/errors.rs
@@ -1,6 +1,12 @@
 use std::io;
 
-pub(crate) use super::errors_impl::*;
+cfg_if::cfg_if! {
+    if #[cfg(any(unix, target_os = "fuchsia"))] {
+        pub(crate) use crate::yanix::fs::errors::*;
+    } else if #[cfg(windows)] {
+        pub(crate) use crate::winx::fs::errors::*;
+    }
+}
 
 #[cold]
 pub(crate) fn escape_attempt() -> io::Error {

--- a/cap-primitives/src/fs/mkdir_via_parent.rs
+++ b/cap-primitives/src/fs/mkdir_via_parent.rs
@@ -14,7 +14,7 @@ pub(crate) fn mkdir_via_parent(
     // it as equivalent to a trailing slash-dot, so strip any trailing slashes.
     let path = strip_dir_suffix(path);
 
-    let (dir, basename) = open_parent(start, path)?;
+    let (dir, basename) = open_parent(start, &path)?;
 
     mkdir_unchecked(&dir, basename.as_ref(), options)
 }

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -5,7 +5,6 @@ mod canonicalize_manually;
 mod dir_builder;
 mod dir_entry;
 mod dir_options;
-pub(crate) mod errors;
 mod file_type;
 mod follow_symlinks;
 #[cfg(not(feature = "no_racy_asserts"))]
@@ -37,6 +36,8 @@ mod symlink;
 mod symlink_via_parent;
 mod unlink;
 mod unlink_via_parent;
+
+pub(crate) mod errors;
 
 pub(crate) use canonicalize_manually::*;
 #[cfg(not(feature = "no_racy_asserts"))]

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -5,6 +5,7 @@ mod canonicalize_manually;
 mod dir_builder;
 mod dir_entry;
 mod dir_options;
+pub(crate) mod errors;
 mod file_type;
 mod follow_symlinks;
 #[cfg(not(feature = "no_racy_asserts"))]

--- a/cap-primitives/src/fs/rename_via_parent.rs
+++ b/cap-primitives/src/fs/rename_via_parent.rs
@@ -17,8 +17,8 @@ pub fn rename_via_parent(
     let old_path = strip_dir_suffix(old_path);
     let new_path = strip_dir_suffix(new_path);
 
-    let (old_dir, old_basename) = open_parent(old_start, old_path)?;
-    let (new_dir, new_basename) = open_parent(new_start, new_path)?;
+    let (old_dir, old_basename) = open_parent(old_start, &old_path)?;
+    let (new_dir, new_basename) = open_parent(new_start, &new_path)?;
 
     rename_unchecked(
         &old_dir,

--- a/cap-primitives/src/winx/fs/errors.rs
+++ b/cap-primitives/src/winx/fs/errors.rs
@@ -1,8 +1,9 @@
 use std::io;
+use winapi::shared::winerror;
 
 #[cold]
 pub(crate) fn no_such_file_or_directory() -> io::Error {
-    todo!("no_such_file_or_directory")
+    io::Error::from_raw_os_error(winerror::ERROR_FILE_NOT_FOUND as i32)
 }
 
 #[cold]
@@ -16,11 +17,6 @@ pub(crate) fn is_not_directory() -> io::Error {
 }
 
 #[cold]
-pub(crate) fn escape_attempt() -> io::Error {
-    todo!("escape_attempt")
-}
-
-#[cold]
 pub(crate) fn too_many_symlinks() -> io::Error {
-    io::Error::from_raw_os_error(winapi::shared::winerror::ERROR_TOO_MANY_LINKS as i32)
+    io::Error::from_raw_os_error(winerror::ERROR_TOO_MANY_LINKS as i32)
 }

--- a/cap-primitives/src/winx/fs/flags.rs
+++ b/cap-primitives/src/winx/fs/flags.rs
@@ -15,10 +15,14 @@ pub(super) fn open_options_to_std(opts: &OpenOptions) -> fs::OpenOptions {
         .truncate(opts.truncate)
         .create(opts.create)
         .create_new(opts.create_new)
-        .access_mode(opts.ext.access_mode)
         .share_mode(opts.ext.share_mode)
         .custom_flags(custom_flags)
         .attributes(opts.ext.attributes)
         .security_qos_flags(opts.ext.security_qos_flags);
+
+    if let Some(access_mode) = opts.ext.access_mode {
+        std_opts.access_mode(access_mode);
+    }
+
     std_opts
 }

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -1,6 +1,7 @@
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
+pub(crate) mod errors;
 mod file_type_ext;
 mod flags;
 mod get_path;
@@ -33,12 +34,11 @@ pub(crate) use crate::fs::{
     unlink_via_parent as unlink_impl,
 };
 
-pub(crate) mod errors;
-
 pub(crate) use crate::fs::open_manually_wrapper as open_impl;
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;
+pub(crate) use errors as errors_impl;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
 pub(crate) use get_path::get_path as get_path_impl;

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -1,7 +1,6 @@
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
-pub(crate) mod errors;
 mod file_type_ext;
 mod flags;
 mod get_path;
@@ -19,6 +18,8 @@ mod rmdir_unchecked;
 mod stat_unchecked;
 mod symlink_unchecked;
 mod unlink_unchecked;
+
+pub(crate) mod errors;
 
 #[rustfmt::skip]
 pub(crate) use crate::fs::{
@@ -38,7 +39,6 @@ pub(crate) use crate::fs::open_manually_wrapper as open_impl;
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;
-pub(crate) use errors as errors_impl;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
 pub(crate) use get_path::get_path as get_path_impl;

--- a/cap-primitives/src/winx/fs/open_options_ext.rs
+++ b/cap-primitives/src/winx/fs/open_options_ext.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone)]
 pub(crate) struct OpenOptionsExt {
-    pub(crate) access_mode: u32,
+    pub(crate) access_mode: Option<u32>,
     pub(crate) share_mode: u32,
     pub(crate) custom_flags: u32,
     pub(crate) attributes: u32,
@@ -10,9 +10,8 @@ pub(crate) struct OpenOptionsExt {
 impl OpenOptionsExt {
     pub(crate) fn new() -> Self {
         use winapi::um::winnt;
-        // TODO figure out the defaults
         Self {
-            access_mode: 0,
+            access_mode: None,
             share_mode: winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE | winnt::FILE_SHARE_DELETE,
             custom_flags: 0,
             attributes: 0,
@@ -23,7 +22,7 @@ impl OpenOptionsExt {
 
 impl std::os::windows::fs::OpenOptionsExt for OpenOptionsExt {
     fn access_mode(&mut self, mode: u32) -> &mut Self {
-        self.access_mode = mode;
+        self.access_mode = Some(mode);
         self
     }
 

--- a/cap-primitives/src/winx/fs/unlink_unchecked.rs
+++ b/cap-primitives/src/winx/fs/unlink_unchecked.rs
@@ -1,6 +1,8 @@
+use super::get_path::concatenate_or_return_absolute;
 use std::{fs, io, path::Path};
 
 /// *Unsandboxed* function similar to `unlink`, but which does not perform sandboxing.
 pub(crate) fn unlink_unchecked(start: &fs::File, path: &Path) -> io::Result<()> {
-    todo!("unlink_unchecked")
+    let full_path = concatenate_or_return_absolute(start, path)?;
+    fs::remove_file(full_path)
 }

--- a/cap-primitives/src/yanix/fs/dir_utils.rs
+++ b/cap-primitives/src/yanix/fs/dir_utils.rs
@@ -1,5 +1,6 @@
 use crate::fs::OpenOptions;
 use std::{
+    borrow::Cow,
     ffi::OsStr,
     fs, io,
     os::unix::{ffi::OsStrExt, fs::OpenOptionsExt},
@@ -34,12 +35,12 @@ pub(crate) fn append_dir_suffix(path: PathBuf) -> PathBuf {
 // used by `mkdir` and others to prevent paths like `foo/` from canonicalizing
 // to `foo/.` since these syscalls treat these differently.
 #[allow(clippy::indexing_slicing)]
-pub(crate) fn strip_dir_suffix(path: &Path) -> &Path {
+pub(crate) fn strip_dir_suffix(path: &Path) -> Cow<Path> {
     let mut bytes = path.as_os_str().as_bytes();
     while bytes.len() > 1 && *bytes.last().unwrap() == b'/' {
         bytes = &bytes[..bytes.len() - 1];
     }
-    OsStr::from_bytes(bytes).as_ref()
+    Cow::Borrowed(OsStr::from_bytes(bytes).as_ref())
 }
 
 // Return an `OpenOptions` for opening directories.

--- a/cap-primitives/src/yanix/fs/errors.rs
+++ b/cap-primitives/src/yanix/fs/errors.rs
@@ -16,14 +16,6 @@ pub(crate) fn is_not_directory() -> io::Error {
 }
 
 #[cold]
-pub(crate) fn escape_attempt() -> io::Error {
-    io::Error::new(
-        io::ErrorKind::PermissionDenied,
-        "a path led outside of the filesystem",
-    )
-}
-
-#[cold]
 pub(crate) fn too_many_symlinks() -> io::Error {
     io::Error::from_raw_os_error(libc::ELOOP)
 }

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -1,7 +1,6 @@
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
-pub(crate) mod errors;
 mod file_type_ext;
 mod flags;
 #[cfg(not(feature = "no_racy_asserts"))]
@@ -20,6 +19,8 @@ mod rmdir_unchecked;
 mod stat_unchecked;
 mod symlink_unchecked;
 mod unlink_unchecked;
+
+pub(crate) mod errors;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
@@ -45,7 +46,6 @@ pub(crate) use crate::fs::{
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;
-pub(crate) use errors as errors_impl;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
 #[cfg(not(feature = "no_racy_asserts"))]

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -1,6 +1,7 @@
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
+pub(crate) mod errors;
 mod file_type_ext;
 mod flags;
 #[cfg(not(feature = "no_racy_asserts"))]
@@ -41,11 +42,10 @@ pub(crate) use crate::fs::{
     unlink_via_parent as unlink_impl,
 };
 
-pub(crate) mod errors;
-
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;
+pub(crate) use errors as errors_impl;
 pub(crate) use file_type_ext::*;
 pub(crate) use flags::*;
 #[cfg(not(feature = "no_racy_asserts"))]

--- a/tests/canonicalize.rs
+++ b/tests/canonicalize.rs
@@ -99,51 +99,27 @@ fn canonicalize_edge_cases() {
 
     assert_eq!(
         check!(tmpdir.canonicalize("foo/bar")),
-        if cfg!(windows) {
-            Path::new("foo\\bar")
-        } else {
-            Path::new("foo/bar")
-        }
+        Path::new("foo").join("bar"),
     );
     assert_eq!(
         check!(tmpdir.canonicalize("foo/bar/")),
-        if cfg!(windows) {
-            Path::new("foo\\bar")
-        } else {
-            Path::new("foo/bar")
-        }
+        Path::new("foo").join("bar")
     );
     assert_eq!(
         check!(tmpdir.canonicalize("foo/bar/")).to_str(),
-        if cfg!(windows) {
-            Some("foo\\bar")
-        } else {
-            Some("foo/bar")
-        }
+        Path::new("foo").join("bar").to_str(),
     );
     assert_eq!(
         check!(tmpdir.canonicalize("foo/../foo/bar")),
-        if cfg!(windows) {
-            Path::new("foo\\bar")
-        } else {
-            Path::new("foo/bar")
-        }
+        Path::new("foo").join("bar")
     );
     assert_eq!(
         check!(tmpdir.canonicalize("foo/../foo/bar/")),
-        if cfg!(windows) {
-            Path::new("foo\\bar")
-        } else {
-            Path::new("foo/bar")
-        }
+        Path::new("foo").join("bar")
     );
     assert_eq!(
         check!(tmpdir.canonicalize("foo/../foo/bar/")).to_str(),
-        if cfg!(windows) {
-            Some("foo\\bar")
-        } else {
-            Some("foo/bar")
-        }
+        Path::new("foo").join("bar").to_str()
     );
     error_contains!(
         tmpdir.canonicalize("foo/../.."),

--- a/tests/cap-basics.rs
+++ b/tests/cap-basics.rs
@@ -14,27 +14,67 @@ fn cap_smoke_test() {
     let inner = check!(tmpdir.open_dir("dir/inner"));
 
     check!(tmpdir.open("red.txt"));
-    error_contains!(tmpdir.open("blue.txt"), "No such file");
-    error_contains!(tmpdir.open("green.txt"), "No such file");
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("blue.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("blue.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("green.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("green.txt"), 2);
 
     check!(tmpdir.open("./red.txt"));
-    error_contains!(tmpdir.open("./blue.txt"), "No such file");
-    error_contains!(tmpdir.open("./green.txt"), "No such file");
 
-    error_contains!(tmpdir.open("dir/red.txt"), "No such file");
+    #[cfg(not(windows))]
+    error!(tmpdir.open("./blue.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("./blue.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("./green.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("./green.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("dir/red.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("dir/red.txt"), 2);
+
     check!(tmpdir.open("dir/green.txt"));
-    error_contains!(tmpdir.open("dir/blue.txt"), "No such file");
 
-    error_contains!(tmpdir.open("dir/inner/red.txt"), "No such file");
-    error_contains!(tmpdir.open("dir/inner/green.txt"), "No such file");
+    #[cfg(not(windows))]
+    error!(tmpdir.open("dir/blue.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("dir/blue.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("dir/inner/red.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("dir/inner/red.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("dir/inner/green.txt"), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.open("dir/inner/green.txt"), 2);
+
     check!(tmpdir.open("dir/inner/blue.txt"));
 
     check!(tmpdir.open("dir/../red.txt"));
     check!(tmpdir.open("dir/inner/../../red.txt"));
     check!(tmpdir.open("dir/inner/../inner/../../red.txt"));
 
-    error_contains!(inner.open("red.txt"), "No such file");
-    error_contains!(inner.open("green.txt"), "No such file");
+    #[cfg(not(windows))]
+    error!(inner.open("red.txt"), "No such file");
+    #[cfg(windows)]
+    error!(inner.open("red.txt"), 2);
+
+    #[cfg(not(windows))]
+    error!(inner.open("green.txt"), "No such file");
+    #[cfg(windows)]
+    error!(inner.open("green.txt"), 2);
+
     error_contains!(
         inner.open("../inner/blue.txt"),
         "a path led outside of the filesystem"
@@ -44,7 +84,11 @@ fn cap_smoke_test() {
         "a path led outside of the filesystem"
     );
 
-    error_contains!(inner.open_dir(""), "No such file");
+    #[cfg(not(windows))]
+    error!(inner.open_dir(""), "No such file");
+    #[cfg(windows)]
+    error!(inner.open_dir(""), 2);
+
     error_contains!(inner.open_dir("/"), "a path led outside of the filesystem");
     error_contains!(
         inner.open_dir("/etc/services"),

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -433,6 +433,7 @@ fn file_test_io_seek_read_write() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_stat_is_correct_on_is_file() {
     let tmpdir = tmpdir();
     let filename = "file_stat_correct_on_is_file.txt";
@@ -452,6 +453,7 @@ fn file_test_stat_is_correct_on_is_file() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_stat_is_correct_on_is_dir() {
     let tmpdir = tmpdir();
     let filename = "file_stat_correct_on_is_dir";
@@ -463,6 +465,7 @@ fn file_test_stat_is_correct_on_is_dir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_fileinfo_false_when_checking_is_file_on_a_directory() {
     let tmpdir = tmpdir();
     let dir = "fileinfo_false_on_dir";
@@ -473,6 +476,7 @@ fn file_test_fileinfo_false_when_checking_is_file_on_a_directory() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
     let tmpdir = tmpdir();
     let file = "fileinfo_check_exists_b_and_a.txt";
@@ -484,6 +488,7 @@ fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_directoryinfo_check_exists_before_and_after_mkdir() {
     let tmpdir = tmpdir();
     let dir = "before_and_after_dir";
@@ -497,6 +502,7 @@ fn file_test_directoryinfo_check_exists_before_and_after_mkdir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn file_test_directoryinfo_readdir() {
     let tmpdir = tmpdir();
     let dir = "di_readdir";
@@ -546,6 +552,7 @@ fn mkdir_path_already_exists_error() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
@@ -555,6 +562,7 @@ fn recursive_mkdir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn recursive_mkdir_failure() {
     let tmpdir = tmpdir();
     let dir = "d1";
@@ -602,6 +610,7 @@ fn recursive_mkdir_slash() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn recursive_mkdir_dot() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all(Path::new(".")));
@@ -615,6 +624,7 @@ fn recursive_mkdir_empty() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn recursive_rmdir() {
     let tmpdir = tmpdir();
     let d1 = PathBuf::from("d1");
@@ -635,6 +645,7 @@ fn recursive_rmdir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn recursive_rmdir_of_symlink() {
     // test we do not recursively delete a symlink but only dirs.
     let tmpdir = tmpdir();
@@ -654,6 +665,7 @@ fn recursive_rmdir_of_symlink() {
 // only Windows makes a distinction between file and directory symlinks.
 #[cfg(windows)]
 #[ignore]
+// TODO enable once more Win syscalls are added
 fn recursive_rmdir_of_file_symlink() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -672,6 +684,7 @@ fn recursive_rmdir_of_file_symlink() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn unicode_path_is_dir() {
     let tmpdir = tmpdir();
 
@@ -692,6 +705,7 @@ fn unicode_path_is_dir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn unicode_path_exists() {
     let tmpdir = tmpdir();
 
@@ -735,6 +749,7 @@ fn copy_src_does_not_exist() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_ok() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -754,6 +769,7 @@ fn copy_file_ok() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_dst_dir() {
     let tmpdir = tmpdir();
     let out = "out";
@@ -767,6 +783,7 @@ fn copy_file_dst_dir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_dst_exists() {
     let tmpdir = tmpdir();
     let input = "in";
@@ -783,6 +800,7 @@ fn copy_file_dst_exists() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_src_dir() {
     let tmpdir = tmpdir();
     let out = "out";
@@ -796,6 +814,7 @@ fn copy_file_src_dir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_preserves_perm_bits() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -830,6 +849,7 @@ fn copy_file_preserves_streams() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_returns_metadata_len() {
     let tmp = tmpdir();
     let in_path = "in.txt";
@@ -843,6 +863,7 @@ fn copy_file_returns_metadata_len() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn copy_file_follows_dst_symlink() {
     let tmp = tmpdir();
     if !got_symlink_permission(&tmp) {
@@ -868,6 +889,7 @@ fn copy_file_follows_dst_symlink() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn symlinks_work() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -893,6 +915,7 @@ fn symlinks_work() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn symlink_noexist() {
     // Symlinks can point to things that don't exist
     let tmpdir = tmpdir();
@@ -908,6 +931,7 @@ fn symlink_noexist() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn read_link() {
     let tmpdir = tmpdir();
     if cfg!(windows) {
@@ -952,6 +976,7 @@ fn readlink_not_symlink() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn links_work() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -985,6 +1010,7 @@ fn links_work() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn chmod_works() {
     let tmpdir = tmpdir();
     let file = "in.txt";
@@ -1014,6 +1040,7 @@ fn chmod_works() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn fchmod_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
@@ -1080,6 +1107,7 @@ fn truncate_works() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn open_flavors() {
     use cap_std::fs::OpenOptions as OO;
     fn c<T: Clone>(t: &T) -> T {
@@ -1312,6 +1340,7 @@ fn canonicalize_works_simple() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn realpath_works() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -1343,6 +1372,7 @@ fn realpath_works() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn realpath_works_tricky() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -1374,6 +1404,7 @@ fn realpath_works_tricky() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn dir_entry_methods() {
     let tmpdir = tmpdir();
 
@@ -1398,6 +1429,7 @@ fn dir_entry_methods() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn dir_entry_debug() {
     let tmpdir = tmpdir();
     tmpdir.create("b").unwrap();
@@ -1410,6 +1442,7 @@ fn dir_entry_debug() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn read_dir_not_found() {
     let tmpdir = tmpdir();
     let res = tmpdir.read_dir("path/that/does/not/exist");
@@ -1418,6 +1451,7 @@ fn read_dir_not_found() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn create_dir_all_with_junctions() {
     let tmpdir = tmpdir();
     let target = "target";
@@ -1448,6 +1482,7 @@ fn create_dir_all_with_junctions() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Win syscalls are added
 fn metadata_access_times() {
     let tmpdir = tmpdir();
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -432,6 +432,7 @@ fn file_test_io_seek_read_write() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_stat_is_correct_on_is_file() {
     let tmpdir = tmpdir();
     let filename = "file_stat_correct_on_is_file.txt";
@@ -450,6 +451,7 @@ fn file_test_stat_is_correct_on_is_file() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_stat_is_correct_on_is_dir() {
     let tmpdir = tmpdir();
     let filename = "file_stat_correct_on_is_dir";
@@ -460,6 +462,7 @@ fn file_test_stat_is_correct_on_is_dir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_fileinfo_false_when_checking_is_file_on_a_directory() {
     let tmpdir = tmpdir();
     let dir = "fileinfo_false_on_dir";
@@ -469,6 +472,7 @@ fn file_test_fileinfo_false_when_checking_is_file_on_a_directory() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
     let tmpdir = tmpdir();
     let file = "fileinfo_check_exists_b_and_a.txt";
@@ -479,6 +483,7 @@ fn file_test_fileinfo_check_exists_before_and_after_file_creation() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_directoryinfo_check_exists_before_and_after_mkdir() {
     let tmpdir = tmpdir();
     let dir = "before_and_after_dir";
@@ -491,6 +496,7 @@ fn file_test_directoryinfo_check_exists_before_and_after_mkdir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn file_test_directoryinfo_readdir() {
     let tmpdir = tmpdir();
     let dir = "di_readdir";
@@ -539,6 +545,7 @@ fn mkdir_path_already_exists_error() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
@@ -547,6 +554,7 @@ fn recursive_mkdir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_mkdir_failure() {
     let tmpdir = tmpdir();
     let dir = "d1";
@@ -593,6 +601,7 @@ fn recursive_mkdir_slash() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_mkdir_dot() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir_all(Path::new(".")));
@@ -605,6 +614,7 @@ fn recursive_mkdir_empty() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_rmdir() {
     let tmpdir = tmpdir();
     let d1 = PathBuf::from("d1");
@@ -624,6 +634,7 @@ fn recursive_rmdir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_rmdir_of_symlink() {
     // test we do not recursively delete a symlink but only dirs.
     let tmpdir = tmpdir();
@@ -642,6 +653,7 @@ fn recursive_rmdir_of_symlink() {
 #[test]
 // only Windows makes a distinction between file and directory symlinks.
 #[cfg(windows)]
+#[ignore]
 fn recursive_rmdir_of_file_symlink() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -659,6 +671,7 @@ fn recursive_rmdir_of_file_symlink() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn unicode_path_is_dir() {
     let tmpdir = tmpdir();
 
@@ -678,6 +691,7 @@ fn unicode_path_is_dir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn unicode_path_exists() {
     let tmpdir = tmpdir();
 
@@ -720,6 +734,7 @@ fn copy_src_does_not_exist() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_ok() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -738,6 +753,7 @@ fn copy_file_ok() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_dst_dir() {
     let tmpdir = tmpdir();
     let out = "out";
@@ -750,6 +766,7 @@ fn copy_file_dst_dir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_dst_exists() {
     let tmpdir = tmpdir();
     let input = "in";
@@ -765,6 +782,7 @@ fn copy_file_dst_exists() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_src_dir() {
     let tmpdir = tmpdir();
     let out = "out";
@@ -777,6 +795,7 @@ fn copy_file_src_dir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_preserves_perm_bits() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -798,6 +817,7 @@ fn copy_file_preserves_perm_bits() {
 
 #[test]
 #[cfg(windows)]
+#[ignore]
 fn copy_file_preserves_streams() {
     let tmp = tmpdir();
     check!(check!(tmp.create("in.txt:bunny")).write("carrot".as_bytes()));
@@ -809,6 +829,7 @@ fn copy_file_preserves_streams() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_returns_metadata_len() {
     let tmp = tmpdir();
     let in_path = "in.txt";
@@ -821,6 +842,7 @@ fn copy_file_returns_metadata_len() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn copy_file_follows_dst_symlink() {
     let tmp = tmpdir();
     if !got_symlink_permission(&tmp) {
@@ -845,6 +867,7 @@ fn copy_file_follows_dst_symlink() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn symlinks_work() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -869,6 +892,7 @@ fn symlinks_work() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn symlink_noexist() {
     // Symlinks can point to things that don't exist
     let tmpdir = tmpdir();
@@ -883,6 +907,7 @@ fn symlink_noexist() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn read_link() {
     let tmpdir = tmpdir();
     if cfg!(windows) {
@@ -926,6 +951,7 @@ fn readlink_not_symlink() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn links_work() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -958,6 +984,7 @@ fn links_work() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn chmod_works() {
     let tmpdir = tmpdir();
     let file = "in.txt";
@@ -986,6 +1013,7 @@ fn chmod_works() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn fchmod_works() {
     let tmpdir = tmpdir();
     let path = "in.txt";
@@ -1051,6 +1079,7 @@ fn truncate_works() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn open_flavors() {
     use cap_std::fs::OpenOptions as OO;
     fn c<T: Clone>(t: &T) -> T {
@@ -1282,6 +1311,7 @@ fn canonicalize_works_simple() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn realpath_works() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -1312,6 +1342,7 @@ fn realpath_works() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn realpath_works_tricky() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {
@@ -1342,6 +1373,7 @@ fn realpath_works_tricky() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn dir_entry_methods() {
     let tmpdir = tmpdir();
 
@@ -1365,6 +1397,7 @@ fn dir_entry_methods() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn dir_entry_debug() {
     let tmpdir = tmpdir();
     tmpdir.create("b").unwrap();
@@ -1376,6 +1409,7 @@ fn dir_entry_debug() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn read_dir_not_found() {
     let tmpdir = tmpdir();
     let res = tmpdir.read_dir("path/that/does/not/exist");
@@ -1383,6 +1417,7 @@ fn read_dir_not_found() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn create_dir_all_with_junctions() {
     let tmpdir = tmpdir();
     let target = "target";
@@ -1412,6 +1447,7 @@ fn create_dir_all_with_junctions() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn metadata_access_times() {
     let tmpdir = tmpdir();
 

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -9,6 +9,7 @@ use cap_std::fs::{DirBuilder, OpenOptions};
 use sys_common::io::tmpdir;
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
@@ -20,13 +21,22 @@ fn recursive_mkdir() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn open_various() {
     let tmpdir = tmpdir();
-    error_contains!(tmpdir.create(""), "No such file");
-    error_contains!(tmpdir.create("."), "Is a directory");
+    #[cfg(not(windows))]
+    error!(tmpdir.create(""), "No such file");
+    #[cfg(windows)]
+    error!(tmpdir.create(""), 2);
+
+    #[cfg(not(windows))]
+    error!(tmpdir.create("."), "Is a directory");
+    #[cfg(windows)]
+    error!(tmpdir.create("."), 2);
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn dir_writable() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir("dir"));
@@ -62,13 +72,19 @@ fn dir_writable() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn trailing_slash() {
     let tmpdir = tmpdir();
     check!(tmpdir.create("file"));
-    error_contains!(tmpdir.open("file/"), "Not a directory");
+
+    #[cfg(not(windows))]
+    error!(tmpdir.open("file/"), "Not a directory");
+    #[cfg(windows)]
+    error!(tmpdir.open("file/"), 2);
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn rename_slashdots() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir("dir"));
@@ -82,6 +98,7 @@ fn rename_slashdots() {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn optionally_recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
@@ -93,9 +110,13 @@ fn optionally_recursive_mkdir() {
 fn optionally_nonrecursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
-    error_contains!(
+    #[cfg(not(windows))]
+    error!(
         tmpdir.create_dir_with(dir, &DirBuilder::new()),
         "No such file"
     );
+    #[cfg(windows)]
+    error!(tmpdir.create_dir_with(dir, &DirBuilder::new()), 2);
+
     assert!(!tmpdir.exists(dir));
 }

--- a/tests/fs_additional.rs
+++ b/tests/fs_additional.rs
@@ -10,6 +10,7 @@ use sys_common::io::tmpdir;
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once `stat_unchecked` is implemented
 fn recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";
@@ -22,6 +23,7 @@ fn recursive_mkdir() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO investigate why this one is failing
 fn open_various() {
     let tmpdir = tmpdir();
     #[cfg(not(windows))]
@@ -37,6 +39,7 @@ fn open_various() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once `stat_unchecked` is implemented
 fn dir_writable() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir("dir"));
@@ -73,6 +76,7 @@ fn dir_writable() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO investigate why this one is failing
 fn trailing_slash() {
     let tmpdir = tmpdir();
     check!(tmpdir.create("file"));
@@ -85,6 +89,7 @@ fn trailing_slash() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once `rename_unchecked` is implemented
 fn rename_slashdots() {
     let tmpdir = tmpdir();
     check!(tmpdir.create_dir("dir"));
@@ -99,6 +104,7 @@ fn rename_slashdots() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once `stat_unchecked` is implemented
 fn optionally_recursive_mkdir() {
     let tmpdir = tmpdir();
     let dir = "d1/d2";

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -30,6 +30,7 @@ fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
 }
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn paths_containing_nul() {
     let tmpdir = tmpdir();
 

--- a/tests/paths-containing-nul.rs
+++ b/tests/paths-containing-nul.rs
@@ -31,6 +31,7 @@ fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Windows syscalls are implemented
 fn paths_containing_nul() {
     let tmpdir = tmpdir();
 

--- a/tests/rename-directory.rs
+++ b/tests/rename-directory.rs
@@ -22,6 +22,7 @@ use sys_common::io::tmpdir;
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Windows syscalls are implemented
 fn rename_directory() {
     let tmpdir = tmpdir();
     let old_path = Path::new("foo/bar/baz");

--- a/tests/rename-directory.rs
+++ b/tests/rename-directory.rs
@@ -21,6 +21,7 @@ use std::{
 use sys_common::io::tmpdir;
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn rename_directory() {
     let tmpdir = tmpdir();
     let old_path = Path::new("foo/bar/baz");

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -65,6 +65,7 @@ cfg_if::cfg_if! {
 
 #[test]
 #[cfg_attr(windows, ignore)]
+// TODO enable once more Windows syscalls are implemented
 fn rename_basics() {
     let tmpdir = tmpdir();
 

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -64,6 +64,7 @@ cfg_if::cfg_if! {
 */
 
 #[test]
+#[cfg_attr(windows, ignore)]
 fn rename_basics() {
     let tmpdir = tmpdir();
 


### PR DESCRIPTION
This large commit implements/fixes enough of Win implementation
to allow for the tests (with several actually ignored until we
implement more functionality) to be compiled and run on Win and
hence the CI.

A cross-platform change is extracting `errors::escape_attempt`
into a cross-platform wide `errors` module since this error
fn is common to all platforms.