### PR TITLE
Remove a redundant `if`.

### DIFF
--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -243,9 +243,7 @@ pub(crate) fn open_manually<'start>(
                         // Normal case
                         let prev_base = base.descend_to(MaybeOwnedFile::owned(file));
                         dirs.push(prev_base);
-                        if one != Component::CurDir.as_os_str() {
-                            canonical_path.push(&one);
-                        }
+                        canonical_path.push(&one);
                     }
                     Err(OpenUncheckedError::Symlink(err)) => {
                         if use_options.follow == FollowSymlinks::No && components.is_empty() {


### PR DESCRIPTION
This was left from an earlier version of the code which pushed `CurDir`
components back onto `components`; the code no longer does that, so we
don't need to check for it anymore.