### PR TITLE
A few minor fixes for Linux's `get_path`

### DIFF
--- a/cap-primitives/src/fs/get_path.rs
+++ b/cap-primitives/src/fs/get_path.rs
@@ -12,7 +12,7 @@ pub(crate) fn get_path(file: &fs::File) -> Option<PathBuf> {
     // `socket:[3556564]` or similar.
     let mut p = PathBuf::from("/proc/self/fd");
     p.push(&file.as_raw_fd().to_string());
-    let path = fs::read_link(p).ok().filter(|path| path.starts_with('/'))?;
+    let path = fs::read_link(p).ok().filter(|path| path.starts_with("/"))?;
 
     // Linux appends the string " (deleted)" when a file is deleted; avoid
     // treating that as the actual name.

--- a/cap-primitives/src/fs/get_path.rs
+++ b/cap-primitives/src/fs/get_path.rs
@@ -14,9 +14,11 @@ pub(crate) fn get_path(file: &fs::File) -> Option<PathBuf> {
         return None;
     }
 
+    // Ignore paths that don't start with '/', which are things like
+    // `socket:[3556564]` or similar.
     let mut p = PathBuf::from("/proc/self/fd");
     p.push(&file.as_raw_fd().to_string());
-    fs::read_link(p).ok()
+    fs::read_link(p).ok().filter(|path| path.starts_with('/'))
 }
 
 #[cfg(target_os = "macos")]

--- a/cap-primitives/src/fs/get_path.rs
+++ b/cap-primitives/src/fs/get_path.rs
@@ -8,7 +8,7 @@ use std::{fs, path::PathBuf};
 pub(crate) fn get_path(file: &fs::File) -> Option<PathBuf> {
     use std::os::unix::{fs::MetadataExt, io::AsRawFd};
 
-    // Linux appends the the string " (deleted)" when a file is deleted; avoid
+    // Linux appends the string " (deleted)" when a file is deleted; avoid
     // treating that as the actual name.
     if file.metadata().ok()?.nlink() == 0 {
         return None;

--- a/cap-primitives/src/fs/get_path.rs
+++ b/cap-primitives/src/fs/get_path.rs
@@ -8,17 +8,19 @@ use std::{fs, path::PathBuf};
 pub(crate) fn get_path(file: &fs::File) -> Option<PathBuf> {
     use std::os::unix::{fs::MetadataExt, io::AsRawFd};
 
+    // Ignore paths that don't start with '/', which are things like
+    // `socket:[3556564]` or similar.
+    let mut p = PathBuf::from("/proc/self/fd");
+    p.push(&file.as_raw_fd().to_string());
+    let path = fs::read_link(p).ok().filter(|path| path.starts_with('/'))?;
+
     // Linux appends the string " (deleted)" when a file is deleted; avoid
     // treating that as the actual name.
     if file.metadata().ok()?.nlink() == 0 {
         return None;
     }
 
-    // Ignore paths that don't start with '/', which are things like
-    // `socket:[3556564]` or similar.
-    let mut p = PathBuf::from("/proc/self/fd");
-    p.push(&file.as_raw_fd().to_string());
-    fs::read_link(p).ok().filter(|path| path.starts_with('/'))
+    Some(path)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
`get_path` is only used by the racy asserts, so it isn't critical, but it's good to be robust in general.