### PR TITLE
Fix Window's `open_unchecked` to return errors when expected

### DIFF
--- a/cap-primitives/src/winx/fs/dir_utils.rs
+++ b/cap-primitives/src/winx/fs/dir_utils.rs
@@ -52,6 +52,12 @@ pub(crate) fn dir_options() -> OpenOptions {
         .clone()
 }
 
+/// Test whether an `OpenOptions` is set to only open directories.
+pub(crate) fn is_dir_options(options: &OpenOptions) -> bool {
+    (options.ext.attributes & Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        == Flags::FILE_FLAG_BACKUP_SEMANTICS.bits()
+}
+
 /// Open a directory named by a bare path, using the host process' ambient
 /// authority.
 ///

--- a/cap-primitives/src/winx/fs/open_unchecked.rs
+++ b/cap-primitives/src/winx/fs/open_unchecked.rs
@@ -1,6 +1,11 @@
 use super::{get_path::concatenate_or_return_absolute, open_options_to_std};
-use crate::fs::{OpenOptions, OpenUncheckedError};
-use std::{fs, io, path::Path};
+use crate::fs::{is_dir_options, FollowSymlinks, OpenOptions, OpenUncheckedError};
+use std::{
+    ffi::OsString,
+    fs, io,
+    os::windows::ffi::{OsStrExt, OsStringExt},
+    path::{Path, PathBuf},
+};
 use winapi::shared::winerror;
 
 /// *Unsandboxed* function similar to `open`, but which does not perform sandboxing.
@@ -9,19 +14,39 @@ pub(crate) fn open_unchecked(
     path: &Path,
     options: &OpenOptions,
 ) -> Result<fs::File, OpenUncheckedError> {
-    let full_path =
+    let mut full_path =
         concatenate_or_return_absolute(start, path).map_err(OpenUncheckedError::Other)?;
+
+    // If we're expected to open this as a directory, append a trailing separator
+    // so that we fail if it's not a directory.
+    if is_dir_options(options) {
+        let mut wide = full_path.into_os_string().encode_wide().collect::<Vec<_>>();
+        wide.push('\\' as u16);
+        full_path = PathBuf::from(OsString::from_wide(&wide));
+    }
+
     let opts = open_options_to_std(options);
     match opts.open(full_path) {
-        Ok(f) => Ok(f),
+        Ok(f) => {
+            if options.follow == FollowSymlinks::No
+                && f.metadata()
+                    .map_err(OpenUncheckedError::Other)?
+                    .file_type()
+                    .is_symlink()
+            {
+                Err(OpenUncheckedError::Symlink(io::Error::new(
+                    io::ErrorKind::Other,
+                    "symlink encountered",
+                )))
+            } else {
+                Ok(f)
+            }
+        }
         Err(e) if e.kind() == io::ErrorKind::NotFound => Err(OpenUncheckedError::NotFound(e)),
         Err(e) => match e.raw_os_error() {
             Some(code) => match code as u32 {
                 winerror::ERROR_FILE_NOT_FOUND | winerror::ERROR_PATH_NOT_FOUND => {
                     Err(OpenUncheckedError::NotFound(e))
-                }
-                winerror::ERROR_REPARSE | winerror::ERROR_REPARSE_OBJECT => {
-                    Err(OpenUncheckedError::Symlink(e))
                 }
                 _ => Err(OpenUncheckedError::Other(e)),
             },

--- a/cap-tempfile/Cargo.toml
+++ b/cap-tempfile/Cargo.toml
@@ -14,5 +14,8 @@ readme = "README.md"
 cap-std = { path = "../cap-std", version = "^0.1.0"}
 uuid = { version = "0.8.1", features = ["v4"] }
 
+[dev-dependencies]
+winapi = { version = "0.3.9", features = ["winerror"] }
+
 [badges]
 maintenance = { status = "actively-developed" }

--- a/cap-tempfile/src/lib.rs
+++ b/cap-tempfile/src/lib.rs
@@ -185,10 +185,15 @@ fn close_tempdir_in() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn close_outer() {
     let t = unsafe { tempdir().unwrap() };
     let _s = tempdir_in(&t).unwrap();
+    #[cfg(windows)]
+    assert_eq!(
+        t.close().unwrap_err().raw_os_error(),
+        Some(winapi::shared::winerror::ERROR_DIR_NOT_EMPTY as i32)
+    );
+    #[cfg(not(windows))]
     t.close().unwrap();
 }
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -792,7 +792,6 @@ fn copy_file_returns_metadata_len() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn copy_file_follows_dst_symlink() {
     let tmp = tmpdir();
     if !got_symlink_permission(&tmp) {
@@ -1357,7 +1356,6 @@ fn read_dir_not_found() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn create_dir_all_with_junctions() {
     let tmpdir = tmpdir();
     let target = "target";


### PR DESCRIPTION
This makes `open_unchecked` return errors when:
 - `follow` is set to `FollowSymlinks::No` and a symlink is found
 - `dir_options()` are used, and the opened object is not a directory

This, along with some fixes in the tests themselves, fixes 4 more tests for Windows.