### PR TITLE
Improve Windows support, and related features

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ extra code to handle absolute paths.
 
 On Linux 5.6 and newer, `cap-std` uses [`openat2`] to implement `open` and with
 a single system call in common cases. Several other operations internally
-utilize `openat2`, [`O_PATH`], and [`/proc/self/fd`] for fast path resolution as
-well.
+utilize [`openat2`], [`O_PATH`], and [`/proc/self/fd`] (when available) for fast
+path resolution as well.
 
 Otherwise, `cap-std` opens each component of a path individually, in order to
 specially handle `..` and symlinks. The algorithm is carefully designed to

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ extra code to handle absolute paths.
 
 On Linux 5.6 and newer, `cap-std` uses [`openat2`] to implement `open` and with
 a single system call in common cases. Several other operations internally
-utilize `openat2` for fast path resolution as well.
+utilize `openat2`, [`O_PATH`], and [`/proc/self/fd`] for fast path resolution as
+well.
 
 Otherwise, `cap-std` opens each component of a path individually, in order to
 specially handle `..` and symlinks. The algorithm is carefully designed to
@@ -121,6 +122,8 @@ calls—it opens `red`, `green`, and then `blue`, and closes the handles for `re
 and `green`.
 
 [`openat2`]: https://lwn.net/Articles/796868/
+[`O_PATH`]: https://man7.org/linux/man-pages/man2/open.2.html
+[`/proc/self/fd`]: https://man7.org/linux/man-pages/man5/proc.5.html
 
 ## What about networking?
 

--- a/cap-async-std/src/fs_utf8/dir.rs
+++ b/cap-async-std/src/fs_utf8/dir.rs
@@ -21,14 +21,10 @@ use async_std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawH
 /// [`async_std::fs::File`].
 ///
 /// Unlike `async_std::fs`, this API's `canonicalize` returns a relative path since
-/// absolute paths don't interoperate well with the capability model. And it lacks
-/// a `set_permissions` method because popular host platforms don't have a way to
-/// perform that operation in a manner compatible with cap-std's sandbox; instead,
-/// open the file and call [`File::set_permissions`].
+/// absolute paths don't interoperate well with the capability model.
 ///
 /// [functions in `async_std::fs`]: https://docs.rs/async-std/latest/async_std/fs/index.html#functions
 /// [`async_std::fs::File`]: https://docs.rs/async-std/latest/async_std/fs/struct.File.html
-/// [`File::set_permissions`]: struct.File.html#method.set_permissions
 pub struct Dir {
     cap_std: crate::fs::Dir,
 }

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -18,6 +18,9 @@ ipnet = "2.3.0"
 yanix = "0.19.0"
 libc = "0.2.72"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+lazy_static = "1.4.0"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 errno = "0.2.6"
 

--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -18,6 +18,12 @@ ipnet = "2.3.0"
 yanix = "0.19.0"
 libc = "0.2.72"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+errno = "0.2.6"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+errno = "0.2.6"
+
 [target.'cfg(windows)'.dependencies]
 winx = "0.19.0"
 winapi = { version = "0.3.9", features = [

--- a/cap-primitives/src/fs/canonicalize.rs
+++ b/cap-primitives/src/fs/canonicalize.rs
@@ -1,5 +1,4 @@
-//! Manual path canonicalization, one component at a time, with manual symlink
-//! resolution, in order to enforce sandboxing.
+//! Sandboxed path canonicalization.
 
 use crate::fs::canonicalize_impl;
 #[cfg(not(feature = "no_racy_asserts"))]

--- a/cap-primitives/src/fs/copy.rs
+++ b/cap-primitives/src/fs/copy.rs
@@ -1,0 +1,16 @@
+use crate::fs::copy_impl;
+use std::{fs, io, path::Path};
+
+/// Copies the contents of one file to another.
+#[inline]
+pub fn copy(
+    from_start: &fs::File,
+    from_path: &Path,
+    to_start: &fs::File,
+    to_path: &Path,
+) -> io::Result<u64> {
+    // In theory we could do extra sanity checks here, but `copy_impl`
+    // implementations use other sandboxed routines to open the files,
+    // so it'd be mostly redundant.
+    copy_impl(from_start, from_path, to_start, to_path)
+}

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -2,6 +2,7 @@
 
 mod canonicalize;
 mod canonicalize_manually;
+mod copy;
 mod dir_builder;
 mod dir_entry;
 mod dir_options;
@@ -67,6 +68,7 @@ pub(crate) use super::winx::fs::*;
 pub(crate) use super::yanix::fs::*;
 
 pub use canonicalize::*;
+pub use copy::*;
 pub use dir_builder::*;
 pub use dir_entry::*;
 pub use dir_options::*;

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -35,6 +35,9 @@ mod rename;
 mod rename_via_parent;
 mod rmdir;
 mod rmdir_via_parent;
+mod set_permissions;
+#[cfg(not(target_os = "linux"))] // doesn't work reliably on linux
+mod set_permissions_via_parent;
 mod stat;
 mod stat_via_parent;
 mod symlink;
@@ -58,6 +61,8 @@ pub(crate) use readlink_one::*;
 pub(crate) use readlink_via_parent::*;
 pub(crate) use rename_via_parent::*;
 pub(crate) use rmdir_via_parent::*;
+#[cfg(not(target_os = "linux"))] // doesn't work reliably on linux
+pub(crate) use set_permissions_via_parent::*;
 pub(crate) use stat_via_parent::*;
 pub(crate) use symlink_via_parent::*;
 pub(crate) use unlink_via_parent::*;
@@ -88,6 +93,7 @@ pub use remove_dir_all::*;
 pub use remove_open_dir::*;
 pub use rename::*;
 pub use rmdir::*;
+pub use set_permissions::*;
 pub use stat::*;
 pub use symlink::*;
 pub use unlink::*;

--- a/cap-primitives/src/fs/set_permissions.rs
+++ b/cap-primitives/src/fs/set_permissions.rs
@@ -1,0 +1,12 @@
+//! This defines `set_permissions`, the primary entrypoint to sandboxed
+//! filesystem permissions modification.
+
+use crate::fs::{set_permissions_impl, Permissions};
+use std::{fs, io, path::Path};
+
+/// Perform a `chmodat`-like operation, ensuring that the resolution of the path
+/// never escapes the directory tree rooted at `start`.
+#[inline]
+pub fn set_permissions(start: &fs::File, path: &Path, perm: Permissions) -> io::Result<()> {
+    set_permissions_impl(start, path, perm)
+}

--- a/cap-primitives/src/fs/set_permissions_via_parent.rs
+++ b/cap-primitives/src/fs/set_permissions_via_parent.rs
@@ -1,0 +1,15 @@
+use crate::fs::{open_parent, set_permissions_unchecked, MaybeOwnedFile, Permissions};
+use std::{fs, io, path::Path};
+
+#[inline]
+pub(crate) fn set_permissions_via_parent(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    let start = MaybeOwnedFile::borrowed(start);
+
+    let (dir, basename) = open_parent(start, &path)?;
+
+    set_permissions_unchecked(&dir, basename.as_ref(), perm)
+}

--- a/cap-primitives/src/lib.rs
+++ b/cap-primitives/src/lib.rs
@@ -17,6 +17,10 @@
     html_favicon_url = "https://raw.githubusercontent.com/sunfishcode/cap-std/main/media/cap-std.ico"
 )]
 
+#[cfg(target_os = "linux")]
+#[macro_use]
+extern crate lazy_static;
+
 #[cfg(windows)]
 mod winx;
 #[cfg(not(windows))]

--- a/cap-primitives/src/winx/fs/copy.rs
+++ b/cap-primitives/src/winx/fs/copy.rs
@@ -1,0 +1,13 @@
+use super::get_path::concatenate_or_return_absolute;
+use std::{fs, io, path::Path};
+
+pub(crate) fn copy_impl(
+    from_start: &fs::File,
+    from_path: &Path,
+    to_start: &fs::File,
+    to_path: &Path,
+) -> io::Result<u64> {
+    let from_full_path = concatenate_or_return_absolute(from_start, from_path)?;
+    let to_full_path = concatenate_or_return_absolute(to_start, to_path)?;
+    fs::copy(from_full_path, to_full_path)
+}

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -1,3 +1,4 @@
+mod copy;
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
@@ -39,6 +40,7 @@ pub(crate) use crate::fs::{
 };
 
 pub(crate) use crate::fs::open_manually_wrapper as open_impl;
+pub(crate) use copy::*;
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -19,6 +19,7 @@ mod remove_dir_all_impl;
 mod remove_open_dir_impl;
 mod rename_unchecked;
 mod rmdir_unchecked;
+mod set_permissions_unchecked;
 mod stat_unchecked;
 mod symlink_unchecked;
 mod unlink_unchecked;
@@ -33,6 +34,7 @@ pub(crate) use crate::fs::{
     readlink_via_parent as readlink_impl,
     rename_via_parent as rename_impl,
     rmdir_via_parent as rmdir_impl,
+    set_permissions_via_parent as set_permissions_impl,
     stat_via_parent as stat_impl,
     symlink_dir_via_parent as symlink_dir_impl,
     symlink_file_via_parent as symlink_file_impl,
@@ -62,6 +64,7 @@ pub(crate) use remove_dir_all_impl::*;
 pub(crate) use remove_open_dir_impl::*;
 pub(crate) use rename_unchecked::*;
 pub(crate) use rmdir_unchecked::*;
+pub(crate) use set_permissions_unchecked::*;
 pub(crate) use stat_unchecked::*;
 pub(crate) use symlink_unchecked::*;
 pub(crate) use unlink_unchecked::*;

--- a/cap-primitives/src/winx/fs/readlink_unchecked.rs
+++ b/cap-primitives/src/winx/fs/readlink_unchecked.rs
@@ -6,9 +6,6 @@ use std::{
 
 /// *Unsandboxed* function similar to `readlink`, but which does not perform sandboxing.
 pub(crate) fn readlink_unchecked(start: &fs::File, path: &Path) -> io::Result<PathBuf> {
-    if path.is_absolute() {
-        return fs::read_link(path);
-    }
     let full_path = concatenate_or_return_absolute(start, path)?;
     fs::read_link(full_path)
 }

--- a/cap-primitives/src/winx/fs/set_permissions_unchecked.rs
+++ b/cap-primitives/src/winx/fs/set_permissions_unchecked.rs
@@ -1,0 +1,19 @@
+use super::get_path::concatenate_or_return_absolute;
+use crate::fs::Permissions;
+use std::{fs, io, path::Path};
+
+/// *Unsandboxed* function similar to `set_permissions`, but which does not perform sandboxing.
+pub(crate) fn set_permissions_unchecked(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    // According to [Rust's documentation], `fs::set_permissions` uses
+    // `SetFileAttributes`, and according to [Windows' documentation]
+    // `SetFileAttributes` does not follow symbolic links.
+    //
+    // [Windows' documentation]: https://docs.microsoft.com/en-us/windows/win32/fileio/symbolic-link-effects-on-file-systems-functions#setfileattributes
+    // [Rust's documentation]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html#platform-specific-behavior
+    let out_path = concatenate_or_return_absolute(start, path)?;
+    fs::set_permissions(out_path, perm.into_std(start)?)
+}

--- a/cap-primitives/src/yanix/fs/copy.rs
+++ b/cap-primitives/src/yanix/fs/copy.rs
@@ -1,0 +1,336 @@
+// Implementation derived from `copy` in Rust's
+// library/std/src/sys/unix/fs.rs at revision
+// f9d17312c9e51e6f9da86db4c6aa7210397ca5f6.
+
+use crate::fs::{open, OpenOptions};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios"
+))]
+use std::os::unix::io::AsRawFd;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::ptr;
+use std::{fs, io, path::Path};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use {std::ffi::CString, std::os::unix::ffi::OsStrExt};
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+macro_rules! syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name: $t),*) -> $ret {
+            weak! { fn $name($($t),*) -> $ret }
+
+            if let Some(fun) = $name.get() {
+                fun($($arg_name),*)
+            } else {
+                errno::set_errno(errno::Errno(libc::ENOSYS));
+                -1
+            }
+        }
+    )
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn cstr(path: &Path) -> io::Result<CString> {
+    Ok(CString::new(path.as_os_str().as_bytes())?)
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn cvt_i32(t: i32) -> io::Result<i32> {
+    if t == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn cvt_i64(t: i64) -> io::Result<i64> {
+    if t == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+fn open_from(start: &fs::File, path: &Path) -> io::Result<(fs::File, fs::Metadata)> {
+    let reader = open(start, path, OpenOptions::new().read(true))?;
+    let metadata = reader.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "the source path is not an existing regular file",
+        ));
+    }
+    Ok((reader, metadata))
+}
+
+fn open_to_and_set_permissions(
+    start: &fs::File,
+    path: &Path,
+    reader_metadata: fs::Metadata,
+) -> io::Result<(fs::File, fs::Metadata)> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let perm = reader_metadata.permissions();
+    let writer = open(
+        start,
+        path,
+        OpenOptions::new()
+            // create the file with the correct mode right away
+            .mode(perm.mode())
+            .write(true)
+            .create(true)
+            .truncate(true),
+    )?;
+    let writer_metadata = writer.metadata()?;
+    if writer_metadata.is_file() {
+        // Set the correct file permissions, in case the file already existed.
+        // Don't set the permissions on already existing non-files like
+        // pipes/FIFOs or device nodes.
+        writer.set_permissions(perm)?;
+    }
+    Ok((writer, writer_metadata))
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios"
+)))]
+pub(crate) fn copy_impl(
+    from_start: &fs::File,
+    from_path: &Path,
+    to_start: &fs::File,
+    to_path: &Path,
+) -> io::Result<u64> {
+    let (mut reader, reader_metadata) = open_from(from_start, from_path)?;
+    let (mut writer, _) = open_to_and_set_permissions(to_start, to_path, reader_metadata)?;
+
+    io::copy(&mut reader, &mut writer)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn copy_impl(
+    from_start: &fs::File,
+    from_path: &Path,
+    to_start: &fs::File,
+    to_path: &Path,
+) -> io::Result<u64> {
+    use std::{
+        cmp,
+        sync::atomic::{AtomicBool, Ordering},
+    };
+
+    // Kernel prior to 4.5 don't have copy_file_range
+    // We store the availability in a global to avoid unnecessary syscalls
+    static HAS_COPY_FILE_RANGE: AtomicBool = AtomicBool::new(true);
+
+    unsafe fn copy_file_range(
+        fd_in: libc::c_int,
+        off_in: *mut libc::loff_t,
+        fd_out: libc::c_int,
+        off_out: *mut libc::loff_t,
+        len: libc::size_t,
+        flags: libc::c_uint,
+    ) -> libc::c_long {
+        libc::syscall(
+            libc::SYS_copy_file_range,
+            fd_in,
+            off_in,
+            fd_out,
+            off_out,
+            len,
+            flags,
+        )
+    }
+
+    let (mut reader, reader_metadata) = open_from(from_start, from_path)?;
+    let len = reader_metadata.len();
+    let (mut writer, _) = open_to_and_set_permissions(to_start, to_path, reader_metadata)?;
+
+    let has_copy_file_range = HAS_COPY_FILE_RANGE.load(Ordering::Relaxed);
+    let mut written = 0_u64;
+    while written < len {
+        let copy_result = if has_copy_file_range {
+            let bytes_to_copy = cmp::min(len - written, usize::MAX as u64) as usize;
+            let copy_result = unsafe {
+                // We actually don't have to adjust the offsets,
+                // because copy_file_range adjusts the file offset automatically
+                cvt_i64(copy_file_range(
+                    reader.as_raw_fd(),
+                    ptr::null_mut(),
+                    writer.as_raw_fd(),
+                    ptr::null_mut(),
+                    bytes_to_copy,
+                    0,
+                ))
+            };
+            if let Err(ref copy_err) = copy_result {
+                match copy_err.raw_os_error() {
+                    Some(libc::ENOSYS) | Some(libc::EPERM) => {
+                        HAS_COPY_FILE_RANGE.store(false, Ordering::Relaxed);
+                    }
+                    _ => {}
+                }
+            }
+            copy_result
+        } else {
+            Err(io::Error::from_raw_os_error(libc::ENOSYS))
+        };
+        match copy_result {
+            Ok(ret) => written += ret as u64,
+            Err(err) => {
+                match err.raw_os_error() {
+                    Some(os_err)
+                        if os_err == libc::ENOSYS
+                            || os_err == libc::EXDEV
+                            || os_err == libc::EINVAL
+                            || os_err == libc::EPERM =>
+                    {
+                        // Try fallback io::copy if either:
+                        // - Kernel version is < 4.5 (ENOSYS)
+                        // - Files are mounted on different fs (EXDEV)
+                        // - copy_file_range is disallowed, for example by seccomp (EPERM)
+                        // - copy_file_range cannot be used with pipes or device nodes (EINVAL)
+                        assert_eq!(written, 0);
+                        return io::copy(&mut reader, &mut writer);
+                    }
+                    _ => return Err(err),
+                }
+            }
+        }
+    }
+    Ok(written)
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[allow(non_upper_case_globals)]
+pub(crate) fn copy_impl(
+    from_start: &fs::File,
+    from_path: &Path,
+    to_start: &fs::File,
+    to_path: &Path,
+) -> io::Result<u64> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const COPYFILE_ACL: u32 = 1 << 0;
+    const COPYFILE_STAT: u32 = 1 << 1;
+    const COPYFILE_XATTR: u32 = 1 << 2;
+    const COPYFILE_DATA: u32 = 1 << 3;
+
+    const COPYFILE_SECURITY: u32 = COPYFILE_STAT | COPYFILE_ACL;
+    const COPYFILE_METADATA: u32 = COPYFILE_SECURITY | COPYFILE_XATTR;
+    const COPYFILE_ALL: u32 = COPYFILE_METADATA | COPYFILE_DATA;
+
+    const COPYFILE_STATE_COPIED: u32 = 8;
+
+    #[allow(non_camel_case_types)]
+    type copyfile_state_t = *mut libc::c_void;
+    #[allow(non_camel_case_types)]
+    type copyfile_flags_t = u32;
+
+    extern "C" {
+        fn fcopyfile(
+            from: libc::c_int,
+            to: libc::c_int,
+            state: copyfile_state_t,
+            flags: copyfile_flags_t,
+        ) -> libc::c_int;
+        fn copyfile_state_alloc() -> copyfile_state_t;
+        fn copyfile_state_free(state: copyfile_state_t) -> libc::c_int;
+        fn copyfile_state_get(
+            state: copyfile_state_t,
+            flag: u32,
+            dst: *mut libc::c_void,
+        ) -> libc::c_int;
+    }
+
+    struct FreeOnDrop(copyfile_state_t);
+    impl Drop for FreeOnDrop {
+        fn drop(&mut self) {
+            // The code below ensures that `FreeOnDrop` is never a null pointer
+            unsafe {
+                // `copyfile_state_free` returns -1 if the `to` or `from` files
+                // cannot be closed. However, this is not considered this an
+                // error.
+                copyfile_state_free(self.0);
+            }
+        }
+    }
+
+    // MacOS prior to 10.12 don't support `fclonefileat`
+    // We store the availability in a global to avoid unnecessary syscalls
+    static HAS_FCLONEFILEAT: AtomicBool = AtomicBool::new(true);
+    syscall! {
+        fn fclonefileat(
+            srcfd: libc::c_int,
+            dst_dirfd: libc::c_int,
+            dst: *const libc::c_char,
+            flags: libc::c_int
+        ) -> libc::c_int
+    }
+
+    let (reader, reader_metadata) = open_from(from_start, from_path)?;
+
+    // Opportunistically attempt to create a copy-on-write clone of `from_path`
+    // using `fclonefileat`.
+    if HAS_FCLONEFILEAT.load(Ordering::Relaxed) {
+        let to_path = cstr(to_path)?;
+        let clonefile_result = cvt_i32(unsafe {
+            fclonefileat(
+                reader.as_raw_fd(),
+                to_start.as_raw_fd(),
+                to_path.as_ptr(),
+                0,
+            )
+        });
+        match clonefile_result {
+            Ok(_) => return Ok(reader_metadata.len()),
+            Err(err) => match err.raw_os_error() {
+                // `fclonefileat` will fail on non-APFS volumes, if the
+                // destination already exists, or if the source and destination
+                // are on different devices. In all these cases `fcopyfile`
+                // should succeed.
+                Some(libc::ENOTSUP) | Some(libc::EEXIST) | Some(libc::EXDEV) => (),
+                Some(libc::ENOSYS) => HAS_FCLONEFILEAT.store(false, Ordering::Relaxed),
+                _ => return Err(err),
+            },
+        }
+    }
+
+    // Fall back to using `fcopyfile` if `fclonefileat` does not succeed.
+    let (writer, writer_metadata) =
+        open_to_and_set_permissions(to_start, to_path, reader_metadata)?;
+
+    // We ensure that `FreeOnDrop` never contains a null pointer so it is
+    // always safe to call `copyfile_state_free`
+    let state = unsafe {
+        let state = copyfile_state_alloc();
+        if state.is_null() {
+            return Err(std::io::Error::last_os_error());
+        }
+        FreeOnDrop(state)
+    };
+
+    let flags = if writer_metadata.is_file() {
+        COPYFILE_ALL
+    } else {
+        COPYFILE_DATA
+    };
+
+    cvt_i32(unsafe { fcopyfile(reader.as_raw_fd(), writer.as_raw_fd(), state.0, flags) })?;
+
+    let mut bytes_copied: libc::off_t = 0;
+    cvt_i32(unsafe {
+        copyfile_state_get(
+            state.0,
+            COPYFILE_STATE_COPIED,
+            &mut bytes_copied as *mut libc::off_t as *mut libc::c_void,
+        )
+    })?;
+    Ok(bytes_copied as u64)
+}

--- a/cap-primitives/src/yanix/fs/flags_impl.rs
+++ b/cap-primitives/src/yanix/fs/flags_impl.rs
@@ -1,11 +1,27 @@
+use super::accmode;
 use std::{fs, io, os::unix::io::AsRawFd};
+use yanix::{fcntl::get_status_flags, file::OFlags};
 
 pub(crate) fn flags_impl(file: &fs::File) -> io::Result<(bool, bool)> {
-    let mode = unsafe { yanix::fcntl::get_status_flags(file.as_raw_fd()) }?;
-    match mode & yanix::file::OFlags::ACCMODE {
-        yanix::file::OFlags::RDONLY => Ok((true, false)),
-        yanix::file::OFlags::RDWR => Ok((true, true)),
-        yanix::file::OFlags::WRONLY => Ok((false, true)),
+    let fd = file.as_raw_fd();
+    let mode = unsafe { get_status_flags(fd) }?;
+
+    // Check for `O_PATH`.
+    // TODO: use yanix's `OFlags::PATH` once it's available.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "emscripten"
+    ))]
+    if mode.contains(OFlags::from_bits(libc::O_PATH).unwrap()) {
+        return Ok((false, false));
+    }
+
+    match mode & accmode() {
+        OFlags::RDONLY => Ok((true, false)),
+        OFlags::RDWR => Ok((true, true)),
+        OFlags::WRONLY => Ok((false, true)),
         _ => unreachable!(),
     }
 }

--- a/cap-primitives/src/yanix/fs/metadata_ext.rs
+++ b/cap-primitives/src/yanix/fs/metadata_ext.rs
@@ -54,7 +54,7 @@ impl MetadataExt {
 
     /// Constructs a new instance of `Metadata` from the given `libc::stat`.
     #[inline]
-    pub(super) fn from_libc(mode: libc::stat) -> Metadata {
+    pub(crate) fn from_libc(mode: libc::stat) -> Metadata {
         Metadata {
             file_type: FileTypeExt::from_libc(mode.st_mode),
             len: u64::try_from(mode.st_size).unwrap(),

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -1,3 +1,4 @@
+mod copy;
 mod dir_entry_inner;
 mod dir_options_ext;
 mod dir_utils;
@@ -55,6 +56,7 @@ pub(crate) use crate::fs::{
     remove_open_dir_by_searching as remove_open_dir_impl,
 };
 
+pub(crate) use copy::*;
 pub(crate) use dir_entry_inner::*;
 pub(crate) use dir_options_ext::*;
 pub(crate) use dir_utils::*;

--- a/cap-primitives/src/yanix/fs/mod.rs
+++ b/cap-primitives/src/yanix/fs/mod.rs
@@ -20,6 +20,8 @@ mod remove_dir_all_impl;
 mod remove_open_dir_by_searching;
 mod rename_unchecked;
 mod rmdir_unchecked;
+#[cfg(not(target_os = "linux"))] // doesn't work reliably on linux
+mod set_permissions_unchecked;
 mod stat_unchecked;
 mod symlink_unchecked;
 mod unlink_unchecked;
@@ -41,11 +43,12 @@ pub(crate) use crate::fs::{
     open_entry_manually as open_entry_impl,
     open_manually_wrapper as open_impl,
     stat_via_parent as stat_impl,
+    canonicalize_manually_and_follow as canonicalize_impl,
+    set_permissions_via_parent as set_permissions_impl,
 };
 
 #[rustfmt::skip]
 pub(crate) use crate::fs::{
-    canonicalize_manually_and_follow as canonicalize_impl,
     link_via_parent as link_impl,
     mkdir_via_parent as mkdir_impl,
     readlink_via_parent as readlink_impl,
@@ -77,6 +80,8 @@ pub(crate) use remove_dir_all_impl::*;
 pub(crate) use remove_open_dir_by_searching::*;
 pub(crate) use rename_unchecked::*;
 pub(crate) use rmdir_unchecked::*;
+#[cfg(not(target_os = "linux"))] // doesn't work reliably on linux
+pub(crate) use set_permissions_unchecked::*;
 pub(crate) use stat_unchecked::*;
 pub(crate) use symlink_unchecked::*;
 pub(crate) use unlink_unchecked::*;

--- a/cap-primitives/src/yanix/fs/set_permissions_unchecked.rs
+++ b/cap-primitives/src/yanix/fs/set_permissions_unchecked.rs
@@ -1,0 +1,35 @@
+use crate::fs::Permissions;
+use std::{convert::TryInto, ffi::CString, fs, io, path::Path};
+#[cfg(unix)]
+use {std::os::unix::ffi::OsStrExt, std::os::unix::fs::PermissionsExt, std::os::unix::io::AsRawFd};
+
+fn cvt_i32(t: i32) -> io::Result<i32> {
+    if t == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+/// *Unsandboxed* function similar to `set_permissions`, but which does not
+/// perform sandboxing.
+///
+/// Note that this function does not work reliably on Linux, since `fchmodat`
+/// with `AT_SYMLINK_NOFOLLOW` is emulated by libc using `/proc` routines that
+/// assume `/proc` is trustworthy.
+#[inline]
+pub(crate) fn set_permissions_unchecked(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    cvt_i32(unsafe {
+        libc::fchmodat(
+            start.as_raw_fd(),
+            CString::new(path.as_os_str().as_bytes())?.as_ptr(),
+            perm.mode().try_into().unwrap(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    })?;
+    Ok(())
+}

--- a/cap-primitives/src/yanix/linux/fs/canonicalize_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/canonicalize_impl.rs
@@ -1,0 +1,53 @@
+//! Path canonicalization using `/proc/self/fd`.
+
+use super::procfs::get_path_from_proc_self_fd;
+use crate::fs::{canonicalize_manually_and_follow, open_beneath, FollowSymlinks, OpenOptions};
+use std::{
+    fs, io,
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+};
+
+/// Implement `canonicalize` by using readlink on `/proc/self/fd/*`.
+pub(crate) fn canonicalize_impl(start: &fs::File, path: &Path) -> io::Result<PathBuf> {
+    // Open the path with `O_PATH`. Use `read(true)` even though we don't need
+    // `read` permissions, because Rust's libstd requires an access mode, and
+    // Linux ignores `O_RDONLY` with `O_PATH`.
+    // TODO: Add O_NOCTTY once yanix has it.
+    let result = open_beneath(
+        start,
+        path,
+        OpenOptions::new()
+            .read(true)
+            .follow(FollowSymlinks::Yes)
+            .custom_flags(libc::O_PATH),
+    );
+
+    // If that worked, call `readlink`.
+    match result {
+        Ok(file) => {
+            if let Ok(start_path) = get_path_from_proc_self_fd(start) {
+                if let Ok(file_path) = get_path_from_proc_self_fd(&file) {
+                    if let Ok(canonical_path) = file_path.strip_prefix(start_path) {
+                        #[cfg(not(feature = "no_racy_asserts"))]
+                        assert_eq!(
+                            canonical_path,
+                            canonicalize_manually_and_follow(start, path).unwrap()
+                        );
+
+                        return Ok(canonical_path.to_path_buf());
+                    }
+                }
+            }
+        }
+        Err(err) => match err.raw_os_error() {
+            // `ENOSYS` from `open_beneath` means `openat2` is unavailable
+            // and we should use a fallback.
+            Some(libc::ENOSYS) => (),
+            _ => return Err(err),
+        },
+    }
+
+    // Use a fallback.
+    canonicalize_manually_and_follow(start, path)
+}

--- a/cap-primitives/src/yanix/linux/fs/file_metadata.rs
+++ b/cap-primitives/src/yanix/linux/fs/file_metadata.rs
@@ -1,0 +1,29 @@
+use crate::fs::{Metadata, MetadataExt};
+use std::{
+    fs, io,
+    os::unix::io::AsRawFd,
+    sync::atomic::{AtomicBool, Ordering::Relaxed},
+};
+use yanix::file::{fstatat, AtFlags};
+
+/// Like `file.metadata()`, but works with `O_PATH` descriptors on old (pre 3.6)
+/// versions of Linux too.
+pub(super) fn file_metadata(file: &fs::File) -> io::Result<Metadata> {
+    // Record whether we've seen an `EBADF` from an `fstat` on an `O_PATH`
+    // file descriptor, meaning we're on a Linux that doesn't support it.
+    static FSTAT_PATH_BADF: AtomicBool = AtomicBool::new(false);
+
+    if !FSTAT_PATH_BADF.load(Relaxed) {
+        match file.metadata() {
+            Ok(metadata) => return Ok(Metadata::from_std(metadata)),
+            Err(e) => match e.raw_os_error() {
+                // Before Linux 3.6, `fstat` with `O_PATH` returned `EBADF`.
+                Some(libc::EBADF) => FSTAT_PATH_BADF.store(true, Relaxed),
+                _ => return Err(e),
+            },
+        }
+    }
+
+    // If `fstat` with `O_PATH` isn't supported, use `fstatat` with `AT_EMPTY_PATH`.
+    unsafe { fstatat(file.as_raw_fd(), "", AtFlags::EMPTY_PATH) }.map(MetadataExt::from_libc)
+}

--- a/cap-primitives/src/yanix/linux/fs/mod.rs
+++ b/cap-primitives/src/yanix/linux/fs/mod.rs
@@ -1,12 +1,20 @@
+mod canonicalize_impl;
 mod ensure_cloexec;
+mod file_metadata;
 mod open_entry_impl;
 mod open_impl;
+mod procfs;
+mod set_permissions_impl;
 mod stat_impl;
 
+pub(crate) use canonicalize_impl::*;
 pub(crate) use ensure_cloexec::*;
 pub(crate) use open_entry_impl::*;
 pub(crate) use open_impl::*;
+pub(crate) use set_permissions_impl::*;
 pub(crate) use stat_impl::*;
+
+use file_metadata::file_metadata;
 
 // In theory we could optimize `link` using `openat2` with `O_PATH` and
 // `linkat` with `AT_EMPTY_PATH`, however that requires `CAP_DAC_READ_SEARCH`,

--- a/cap-primitives/src/yanix/linux/fs/open_entry_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/open_entry_impl.rs
@@ -1,4 +1,4 @@
-use crate::fs::{open_entry_manually, open_with_openat2, OpenOptions};
+use crate::fs::{open_beneath, open_entry_manually, OpenOptions};
 use std::{ffi::OsStr, fs, io};
 
 pub(crate) fn open_entry_impl(
@@ -6,7 +6,7 @@ pub(crate) fn open_entry_impl(
     path: &OsStr,
     options: &OpenOptions,
 ) -> io::Result<fs::File> {
-    let result = open_with_openat2(start, path.as_ref(), options);
+    let result = open_beneath(start, path.as_ref(), options);
 
     match result {
         Ok(file) => Ok(file),

--- a/cap-primitives/src/yanix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/open_impl.rs
@@ -41,7 +41,7 @@ pub(crate) fn open_impl(
     path: &Path,
     options: &OpenOptions,
 ) -> io::Result<fs::File> {
-    let result = open_with_openat2(start, path, options);
+    let result = open_beneath(start, path, options);
 
     // If that returned `ENOSYS`, use a fallback strategy.
     if let Err(e) = &result {
@@ -53,10 +53,10 @@ pub(crate) fn open_impl(
     result
 }
 
-/// Call the `openat2` system call. If the syscall is unavailable, mark it so
-/// for future calls. If `openat2` is unavailable either permanently or
-/// temporarily, return `ENOSYS`.
-pub(crate) fn open_with_openat2(
+/// Call the `openat2` system call with `RESOLVE_BENEATH`. If the syscall is
+/// unavailable, mark it so for future calls. If `openat2` is unavailable
+/// either permanently or temporarily, return `ENOSYS`.
+pub(crate) fn open_beneath(
     start: &fs::File,
     path: &Path,
     options: &OpenOptions,

--- a/cap-primitives/src/yanix/linux/fs/open_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/open_impl.rs
@@ -1,9 +1,9 @@
 //! Linux 5.6 and later have a syscall `openat2`, with flags that allow it to
 //! enforce the sandboxing property we want. See the [LWN article] for an
-//! overview and the [openat2 documentation] for details.
+//! overview and the [`openat2` documentation] for details.
 //!
 //! [LWN article]: https://lwn.net/Articles/796868/
-//! [openat2 documentation]: https://man7.org/linux/man-pages/man2/openat2.2.html
+//! [`openat2` documentation]: https://man7.org/linux/man-pages/man2/openat2.2.html
 //!
 //! On older Linux, fall back to `open_manually`.
 
@@ -71,7 +71,7 @@ pub(crate) fn open_beneath(
         let mode = if (oflags.bits() & libc::O_CREAT == libc::O_CREAT)
             || (oflags.bits() & libc::O_TMPFILE == libc::O_TMPFILE)
         {
-            options.ext.mode
+            options.ext.mode & 0o7777
         } else {
             0
         };

--- a/cap-primitives/src/yanix/linux/fs/procfs.rs
+++ b/cap-primitives/src/yanix/linux/fs/procfs.rs
@@ -1,0 +1,194 @@
+use super::file_metadata;
+use crate::fs::{open_unchecked, readlink_unchecked, FollowSymlinks, OpenOptions};
+use std::{
+    ffi::CString,
+    fs, io,
+    mem::MaybeUninit,
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+        io::AsRawFd,
+    },
+    path::{Path, PathBuf},
+};
+
+/// Linux's procfs always uses inode 1 for its root directory.
+const PROC_ROOT_INO: u64 = 1;
+
+/// The filesystem magic number for procfs.
+///
+/// This is defined in the `libc` crate for linux-gnu but not for
+/// linux-musl, so we define it ourselves.
+#[cfg(not(target_env = "musl"))]
+const PROC_SUPER_MAGIC: libc::c_long = 0x0000_9fa0;
+#[cfg(target_env = "musl")]
+const PROC_SUPER_MAGIC: libc::c_ulong = 0x0000_9fa0;
+
+lazy_static! {
+    static ref PROC_SELF_FD: io::Result<fs::File> = init_proc_self_fd();
+}
+
+fn init_proc_self_fd() -> io::Result<fs::File> {
+    // Open "/proc".
+    // TODO: Here and below, add O_NOCTTY once yanix has it.
+    let proc = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open("/proc")?;
+
+    // Check the filesystem magic.
+    confirm_procfs(&proc)?;
+
+    let proc_metadata = file_metadata(&proc)?;
+
+    if !proc_metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc isn't a directory",
+        ));
+    }
+
+    // Check the root inode number.
+    if proc_metadata.ino() != PROC_ROOT_INO {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "unexpected root inode in /proc",
+        ));
+    }
+
+    // Check that root owns "/proc".
+    if proc_metadata.uid() != 0 || proc_metadata.gid() != 0 || proc_metadata.mode() != 0o40555 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc isn't owned by root",
+        ));
+    }
+
+    // Check that the "/proc" directory isn't empty.
+    if proc_metadata.nlink() <= 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc appears to not have subdirectories",
+        ));
+    }
+
+    // Open "/proc/self/fd". Use `read(true) even though we don't need `read`
+    // permissions, because Rust's libstd requires an access mode, and Linux
+    // ignores `O_RDONLY` with `O_PATH`.
+    let proc_self_fd = open_unchecked(
+        &proc,
+        Path::new("self/fd"),
+        OpenOptions::new()
+            .read(true)
+            .follow(FollowSymlinks::No)
+            .custom_flags(libc::O_PATH | libc::O_DIRECTORY),
+    )?;
+
+    // Double-check that "/proc/self/fd" is still in procfs.
+    confirm_procfs(&proc_self_fd)?;
+
+    // Check that /proc is sane.
+    let proc_self_fd_metadata = file_metadata(&proc_self_fd)?;
+
+    if proc_self_fd_metadata.ino() == PROC_ROOT_INO {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "unexpected non-root inode in /proc/self/fd",
+        ));
+    }
+
+    // Triple-check that we're still in procfs.
+    if proc_self_fd_metadata.dev() != proc_metadata.dev() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc/self/fd is on a different filesystem from /proc",
+        ));
+    }
+
+    // Check that our process owns the "/proc/self/fd" directory.
+    if proc_self_fd_metadata.uid() != unsafe { libc::getuid() }
+        || proc_self_fd_metadata.gid() != unsafe { libc::getgid() }
+        || proc_self_fd_metadata.mode() != 0o40500
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc/self/fd isn't owned by the process' owner",
+        ));
+    }
+
+    // Check that the "/proc/self/fd" directory doesn't have any extraneous
+    // links into it (which would include unexpected subdirectories).
+    if proc_self_fd_metadata.nlink() != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "/proc/self/fd has an unexpected number of links",
+        ));
+    }
+
+    Ok(proc_self_fd)
+}
+
+fn proc_self_fd() -> io::Result<&'static fs::File> {
+    PROC_SELF_FD
+        .as_ref()
+        .map_err(|e| io::Error::new(e.kind(), e.to_string()))
+}
+
+fn confirm_procfs(file: &fs::File) -> io::Result<()> {
+    let mut statfs = MaybeUninit::<libc::statfs>::uninit();
+    cvt_i32(unsafe { libc::fstatfs(file.as_raw_fd(), statfs.as_mut_ptr()) })?;
+
+    let f_type = unsafe { statfs.assume_init() }.f_type;
+    if f_type != PROC_SUPER_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("unexpected filesystem type in /proc ({:#x})", f_type),
+        ));
+    }
+
+    Ok(())
+}
+
+fn cvt_i32(t: i32) -> io::Result<i32> {
+    if t == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+fn cstr(path: &Path) -> io::Result<CString> {
+    Ok(CString::new(path.as_os_str().as_bytes())?)
+}
+
+pub(crate) fn get_path_from_proc_self_fd(file: &fs::File) -> io::Result<PathBuf> {
+    readlink_unchecked(proc_self_fd()?, Path::new(&file.as_raw_fd().to_string()))
+        .map_err(Into::into)
+}
+
+pub(crate) fn set_permissions_through_proc_self_fd(
+    file: &fs::File,
+    perm: fs::Permissions,
+) -> io::Result<()> {
+    // We the `fchmodat` below to follow the magiclink, but if that resolves
+    // to a symlink, we want it to stop following. So check for the file being
+    // a symlink first.
+    if file_metadata(file)?.file_type().is_symlink() {
+        return Err(io::Error::from_raw_os_error(libc::ENOTSUP));
+    }
+
+    // Don't pass `AT_SYMLINK_NOFOLLOW`, because (a) Linux doesn't support it,
+    // (b) some Linux libc implementations emulate it using procfs but without
+    // the safety checks we do, and (c) we do actually want to follow the first
+    // symlink. We don't want to follow any subsequent symlinks, but the check
+    // above ensures that the destination of the link isn't a symlink.
+    let atflags = 0;
+
+    let fd = proc_self_fd()?.as_raw_fd();
+    let mode = perm.mode();
+    let cstr = cstr(Path::new(&file.as_raw_fd().to_string()))?;
+
+    cvt_i32(unsafe { libc::fchmodat(fd, cstr.as_ptr(), mode, atflags) })?;
+
+    Ok(())
+}

--- a/cap-primitives/src/yanix/linux/fs/set_permissions_impl.rs
+++ b/cap-primitives/src/yanix/linux/fs/set_permissions_impl.rs
@@ -1,0 +1,113 @@
+use super::procfs::set_permissions_through_proc_self_fd;
+use crate::fs::{open, FollowSymlinks, OpenOptions, Permissions};
+use std::{
+    fs, io,
+    os::unix::{
+        fs::{OpenOptionsExt, PermissionsExt},
+        io::AsRawFd,
+    },
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering::Relaxed},
+};
+
+/// Note that we can't use `fchmodat` because Linux's `fchmodat` system call
+/// doesn't support the `AT_SYMLINK_NOFOLLOW` flag. GLIBC and musl have
+/// support for emulating that flag, however they do so by relying on `/proc`
+/// in a way that trusts that `/proc` is reliable, so we don't use them here.
+///
+/// In the future, Linux may add an [`fchmodat4`] system call, which would
+/// give us a single reliable way to do this.
+///
+/// [`fchmodat4`]: https://lwn.net/Articles/792628/
+pub(crate) fn set_permissions_impl(
+    start: &fs::File,
+    path: &Path,
+    perm: Permissions,
+) -> io::Result<()> {
+    // Record whether we've seen an `EBADF` from an `fchmod` on an `O_PATH`
+    // file descriptor, meaning we're on a Linux that doesn't support it.
+    static FCHMOD_PATH_BADF: AtomicBool = AtomicBool::new(false);
+
+    let std_perm = perm.into_std(start)?;
+
+    if !FCHMOD_PATH_BADF.load(Relaxed) {
+        // First try to open the path with `O_PATH`; if that succeeds, it'll give
+        // us a few options. Use `read(true)` even though we don't need `read`
+        // permissions, because Rust's libstd requires an access mode, and Linux
+        // ignores `O_RDONLY` with `O_PATH`.
+        // TODO: Add tests with no-read no-permissions.
+        // TODO: Here and below, use O_NOCTTY once yanix has it.
+        let opath_result = open(
+            start,
+            path,
+            OpenOptions::new()
+                .read(true)
+                .follow(FollowSymlinks::Yes)
+                .custom_flags(libc::O_PATH),
+        );
+
+        // If `O_PATH` worked, try to use `fchmod` on it.
+        if let Ok(file) = opath_result {
+            match file_set_permissions(&file, std_perm.clone()) {
+                Ok(()) => return Ok(()),
+                Err(e) => match e.raw_os_error() {
+                    // If it fails with `EBADF`, `fchmod` didn't like `O_PATH`,
+                    // so proceed to the fallback strategies below.
+                    Some(libc::EBADF) => FCHMOD_PATH_BADF.store(true, Relaxed),
+                    _ => return Err(e),
+                },
+            }
+        }
+    }
+
+    // Then try `fchmod` with a normal handle. Normal handles need some kind of
+    // access, so first try read.
+    match open(
+        start,
+        path,
+        OpenOptions::new().read(true).follow(FollowSymlinks::Yes),
+    ) {
+        Ok(file) => return file_set_permissions(&file, std_perm),
+        Err(e) => match e.raw_os_error() {
+            Some(libc::EACCES) => (),
+            _ => return Err(e),
+        },
+    }
+
+    // Next try write.
+    match open(
+        start,
+        path,
+        OpenOptions::new().write(true).follow(FollowSymlinks::Yes),
+    ) {
+        Ok(file) => return file_set_permissions(&file, std_perm),
+        Err(e) => match e.raw_os_error() {
+            Some(libc::EACCES) | Some(libc::EISDIR) => (),
+            _ => return Err(e),
+        },
+    }
+
+    // If neither of those worked, turn to `/proc`.
+    let opath_result = open(
+        start,
+        path,
+        OpenOptions::new()
+            .read(true)
+            .follow(FollowSymlinks::Yes)
+            .custom_flags(libc::O_PATH),
+    );
+    set_permissions_through_proc_self_fd(&opath_result?, std_perm)
+}
+
+/// Like `file.set_permissions(perm)`, but without dependeing on libc's
+/// `fchmod`, since some libc implementations such as musl emulate `O_PATH`
+/// support by emulating it with /proc.
+fn file_set_permissions(file: &fs::File, perm: fs::Permissions) -> io::Result<()> {
+    let fd = file.as_raw_fd();
+    let mode = perm.mode();
+    if unsafe { libc::syscall(libc::SYS_fchmod, fd, mode) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}

--- a/cap-primitives/src/yanix/mod.rs
+++ b/cap-primitives/src/yanix/mod.rs
@@ -3,5 +3,7 @@
 
 #[cfg(target_os = "linux")]
 mod linux;
+#[macro_use]
+mod weak;
 
 pub(crate) mod fs;

--- a/cap-primitives/src/yanix/weak.rs
+++ b/cap-primitives/src/yanix/weak.rs
@@ -1,0 +1,111 @@
+// Implementation derived from `weak` in Rust's
+// library/std/src/sys/unix/weak.rs at revision
+// f9d17312c9e51e6f9da86db4c6aa7210397ca5f6.
+
+//! Support for "weak linkage" to symbols on Unix
+//!
+//! Some I/O operations we do in libstd require newer versions of OSes but we
+//! need to maintain binary compatibility with older releases for now. In order
+//! to use the new functionality when available we use this module for
+//! detection.
+//!
+//! One option to use here is weak linkage, but that is unfortunately only
+//! really workable on Linux. Hence, use dlsym to get the symbol value at
+//! runtime. This is also done for compatibility with older versions of glibc,
+//! and to avoid creating dependencies on `GLIBC_PRIVATE` symbols. It assumes that
+//! we've been dynamically linked to the library the symbol comes from, but that
+//! is currently always the case for things like libpthread/libc.
+//!
+//! A long time ago this used weak linkage for the `__pthread_get_minstack`
+//! symbol, but that caused Debian to detect an unnecessarily strict versioned
+//! dependency on libc6 (#23628).
+
+// There are a variety of `#[cfg]`s controlling which targets are involved in
+// each instance of `weak!` and `syscall!`. Rather than trying to unify all of
+// that, we'll just allow that some unix targets don't use this module at all.
+#![allow(dead_code, unused_macros)]
+#![allow(clippy::doc_markdown)]
+
+use std::{
+    ffi::CStr,
+    marker, mem,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+macro_rules! weak {
+    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
+        static $name: crate::yanix::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+            crate::yanix::weak::Weak::new(concat!(stringify!($name), '\0'));
+    )
+}
+
+pub(crate) struct Weak<F> {
+    name: &'static str,
+    addr: AtomicUsize,
+    _marker: marker::PhantomData<F>,
+}
+
+impl<F> Weak<F> {
+    pub(crate) const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            addr: AtomicUsize::new(1),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    pub(crate) fn get(&self) -> Option<F> {
+        assert_eq!(mem::size_of::<F>(), mem::size_of::<usize>());
+        unsafe {
+            if self.addr.load(Ordering::SeqCst) == 1 {
+                self.addr.store(fetch(self.name), Ordering::SeqCst);
+            }
+            match self.addr.load(Ordering::SeqCst) {
+                0 => None,
+                addr => Some(mem::transmute_copy::<usize, F>(&addr)),
+            }
+        }
+    }
+}
+
+unsafe fn fetch(name: &str) -> usize {
+    let name = match CStr::from_bytes_with_nul(name.as_bytes()) {
+        Ok(cstr) => cstr,
+        Err(..) => return 0,
+    };
+    libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr()) as usize
+}
+
+#[cfg(not(target_os = "linux"))]
+macro_rules! syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name: $t),*) -> $ret {
+            use super::os;
+
+            weak! { fn $name($($t),*) -> $ret }
+
+            if let Some(fun) = $name.get() {
+                fun($($arg_name),*)
+            } else {
+                os::set_errno(libc::ENOSYS);
+                -1
+            }
+        }
+    )
+}
+
+#[cfg(target_os = "linux")]
+macro_rules! syscall {
+    (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
+        unsafe fn $name($($arg_name:$t),*) -> $ret {
+            // This looks like a hack, but concat_idents only accepts idents
+            // (not paths).
+            use libc::*;
+
+            syscall(
+                concat_idents!(SYS_, $name),
+                $($arg_name as c_long),*
+            ) as $ret
+        }
+    )
+}

--- a/cap-std/src/fs/dir.rs
+++ b/cap-std/src/fs/dir.rs
@@ -1,8 +1,8 @@
 use crate::fs::{DirBuilder, File, Metadata, OpenOptions, ReadDir};
 use cap_primitives::fs::{
     canonicalize, copy, link, mkdir, open, open_ambient_dir, open_dir, read_dir, readlink,
-    remove_dir_all, remove_open_dir, remove_open_dir_all, rename, rmdir, stat, unlink, DirOptions,
-    FollowSymlinks,
+    remove_dir_all, remove_open_dir, remove_open_dir_all, rename, rmdir, set_permissions, stat,
+    unlink, DirOptions, FollowSymlinks, Permissions,
 };
 use std::{
     fmt, fs,
@@ -36,14 +36,10 @@ use std::os::wasi::{
 /// [`std::fs::File`].
 ///
 /// Unlike `std::fs`, this API's `canonicalize` returns a relative path since
-/// absolute paths don't interoperate well with the capability model. And it lacks
-/// a `set_permissions` method because popular host platforms don't have a way to
-/// perform that operation in a manner compatible with cap-std's sandbox; instead,
-/// open the file and call [`File::set_permissions`].
+/// absolute paths don't interoperate well with the capability model.
 ///
 /// [functions in `std::fs`]: https://doc.rust-lang.org/std/fs/index.html#functions
 /// [`std::fs::File`]: https://doc.rust-lang.org/std/fs/struct.File.html
-/// [`File::set_permissions`]: struct.File.html#method.set_permissions
 pub struct Dir {
     std_file: fs::File,
 }
@@ -371,6 +367,16 @@ impl Dir {
         to: Q,
     ) -> io::Result<()> {
         rename(&self.std_file, from.as_ref(), &to_dir.std_file, to.as_ref())
+    }
+
+    /// Changes the permissions found on a file or a directory.
+    ///
+    /// This corresponds to [`std::fs::set_permissions`], but only accesses paths
+    /// relative to `self`.
+    ///
+    /// [`std::fs::set_permissions`]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
+    pub fn set_permissions<P: AsRef<Path>>(&self, path: P, perm: Permissions) -> io::Result<()> {
+        set_permissions(&self.std_file, path.as_ref(), perm)
     }
 
     /// Query the metadata about a file without following symlinks.

--- a/cap-std/src/fs_utf8/dir.rs
+++ b/cap-std/src/fs_utf8/dir.rs
@@ -1,5 +1,5 @@
 use crate::{
-    fs::OpenOptions,
+    fs::{OpenOptions, Permissions},
     fs_utf8::{from_utf8, to_utf8, DirBuilder, File, Metadata, ReadDir},
 };
 use std::{fmt, fs, io};
@@ -20,14 +20,10 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle}
 /// [`std::fs::File`].
 ///
 /// Unlike `std::fs`, this API's `canonicalize` returns a relative path since
-/// absolute paths don't interoperate well with the capability model. And it lacks
-/// a `set_permissions` method because popular host platforms don't have a way to
-/// perform that operation in a manner compatible with cap-std's sandbox; instead,
-/// open the file and call [`File::set_permissions`].
+/// absolute paths don't interoperate well with the capability model.
 ///
 /// [functions in `std::fs`]: https://doc.rust-lang.org/std/fs/index.html#functions
 /// [`std::fs::File`]: https://doc.rust-lang.org/std/fs/struct.File.html
-/// [`File::set_permissions`]: struct.File.html#method.set_permissions
 pub struct Dir {
     cap_std: crate::fs::Dir,
 }
@@ -320,6 +316,17 @@ impl Dir {
         let from = from_utf8(from)?;
         let to = from_utf8(to)?;
         self.cap_std.rename(from, &to_dir.cap_std, to)
+    }
+
+    /// Changes the permissions found on a file or a directory.
+    ///
+    /// This corresponds to [`std::fs::set_permissions`], but only accesses paths
+    /// relative to `self`.
+    ///
+    /// [`std::fs::set_permissions`]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
+    pub fn set_permissions<P: AsRef<str>>(&self, path: P, perm: Permissions) -> io::Result<()> {
+        let path = from_utf8(path)?;
+        self.cap_std.set_permissions(path, perm)
     }
 
     /// Query the metadata about a file without following symlinks.

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -746,7 +746,6 @@ fn copy_file_src_dir() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn copy_file_preserves_perm_bits() {
     let tmpdir = tmpdir();
     let input = "in.txt";
@@ -768,7 +767,6 @@ fn copy_file_preserves_perm_bits() {
 
 #[test]
 #[cfg(windows)]
-#[ignore] // TODO investigate why this one is failing
 fn copy_file_preserves_streams() {
     let tmp = tmpdir();
     check!(check!(tmp.create("in.txt:bunny")).write("carrot".as_bytes()));


### PR DESCRIPTION
This switches to platform-dependent `copy` implementations, as I expect that'll clear up some remaining issues on Windows. And it adds `Dir::set_permissions`, because on Windows opening a file and doing `set_permissions` on it doesn't always work.

That led me to implement `Dir::set_permissions` on Linux too, which was previously omitted because it's complex to implement on Linux, because Linux doesn't support `AT_SYMLINK_NOFOLLOW` in `fchmodat`. Implementing it required `/proc/self/fd` support, with lots of checks to make sure /proc is procfs and doesn't have other things mounted over it.

And with `/proc/self/fd` support, it's now straightforward to use it to optimize `canonicalize` for Linux as well.