### PR TITLE
Fix the remaining Windows failures in tests/fs.rs.

### DIFF
--- a/cap-primitives/README.md
+++ b/cap-primitives/README.md
@@ -15,10 +15,8 @@
 The `cap-primitives` crate provides primitive sandboxing operations that
 [`cap-std`] and [`cap-async-std`] are built on.
 
-The filesystem module, [`cap_std::fs`], is known to compile on Linux, macOS, and
-FreeBSD, and probably can be easily ported to other modern Unix-family platforms.
-Windows support is in development; basic functionality works, but not all features
-are implemented yet. WASI support is in development, though not yet usable.
+The filesystem module, [`cap_std::fs`], currently supports Linux, macOS,
+FreeBSD, and Windows. WASI support is in development, though not yet usable.
 
 The networking module, `net`, is not yet usable.
 

--- a/cap-primitives/src/fs/canonicalize_manually.rs
+++ b/cap-primitives/src/fs/canonicalize_manually.rs
@@ -1,7 +1,7 @@
 //! Manual path canonicalization, one component at a time, with manual symlink
 //! resolution, in order to enforce sandboxing.
 
-use crate::fs::{open_manually, FollowSymlinks, MaybeOwnedFile, OpenOptions};
+use crate::fs::{canonicalize_options, open_manually, FollowSymlinks, MaybeOwnedFile};
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -31,7 +31,7 @@ pub(crate) fn canonicalize_manually(
     if let Err(e) = open_manually(
         start,
         path,
-        OpenOptions::new().read(true).follow(follow),
+        canonicalize_options().follow(follow),
         &mut symlink_count,
         Some(&mut canonical_path),
     ) {

--- a/cap-primitives/src/fs/mod.rs
+++ b/cap-primitives/src/fs/mod.rs
@@ -28,6 +28,7 @@ mod permissions;
 mod read_dir;
 mod readlink;
 mod readlink_one;
+#[cfg(not(windows))] // doesn't work on windows; use a windows-specific impl
 mod readlink_via_parent;
 mod remove_dir_all;
 mod remove_open_dir;
@@ -58,6 +59,7 @@ pub(crate) use open_entry_manually::*;
 pub(crate) use open_manually::*;
 pub(crate) use open_parent::*;
 pub(crate) use readlink_one::*;
+#[cfg(not(windows))] // doesn't work on windows; use a windows-specific impl
 pub(crate) use readlink_via_parent::*;
 pub(crate) use rename_via_parent::*;
 pub(crate) use rmdir_via_parent::*;

--- a/cap-primitives/src/fs/open_manually.rs
+++ b/cap-primitives/src/fs/open_manually.rs
@@ -209,7 +209,7 @@ pub(crate) fn open_manually<'start>(
                     return Err(errors::is_directory());
                 }
 
-                let use_options = if components.is_empty() && !dir_required {
+                let use_options = if components.is_empty() {
                     options
                 } else {
                     &dir_options
@@ -217,7 +217,10 @@ pub(crate) fn open_manually<'start>(
                 match open_unchecked(
                     &base,
                     one.as_ref(),
-                    use_options.clone().follow(FollowSymlinks::No),
+                    use_options
+                        .clone()
+                        .follow(FollowSymlinks::No)
+                        .dir_required(dir_required),
                 ) {
                     Ok(file) => {
                         // Emulate `O_PATH` + `FollowSymlinks::Yes` on Linux. If `file` is a

--- a/cap-primitives/src/fs/open_options.rs
+++ b/cap-primitives/src/fs/open_options.rs
@@ -24,6 +24,7 @@ pub struct OpenOptions {
     pub(crate) truncate: bool,
     pub(crate) create: bool,
     pub(crate) create_new: bool,
+    pub(crate) dir_required: bool,
     pub(crate) follow: FollowSymlinks,
 
     #[cfg(any(unix, windows, target_os = "vxworks"))]
@@ -46,6 +47,7 @@ impl OpenOptions {
             truncate: false,
             create: false,
             create_new: false,
+            dir_required: false,
             follow: FollowSymlinks::Yes,
 
             #[cfg(any(unix, windows, target_os = "vxworks"))]
@@ -123,6 +125,13 @@ impl OpenOptions {
     #[inline]
     pub(crate) fn follow(&mut self, follow: FollowSymlinks) -> &mut Self {
         self.follow = follow;
+        self
+    }
+
+    /// Sets the option to enable an error if the opened object is not a directory.
+    #[inline]
+    pub(crate) fn dir_required(&mut self, dir_required: bool) -> &mut Self {
+        self.dir_required = dir_required;
         self
     }
 }

--- a/cap-primitives/src/fs/readlink_via_parent.rs
+++ b/cap-primitives/src/fs/readlink_via_parent.rs
@@ -4,8 +4,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Implement `readlink` by `open`ing up the parent component of the path and then
-/// calling `readlink_unchecked` on the last component.
+/// Implement `readlink` by `open`ing up the parent component of the path and
+/// then calling `readlink_unchecked` on the last component.
+///
+/// Note that this technique doesn't work in all cases on Windows. In
+/// particular, a directory symlink such as `C:\Documents and Settings` may not
+/// grant any access other than what is needed to resolve the symlink, so
+/// `open_parent`'s technique of returning a relative path of `.` from that
+/// point doesn't work, because opening `.` within such a directory is denied.
+/// Consequently, we use a different implementation on Windows.
 pub(crate) fn readlink_via_parent(start: &fs::File, path: &Path) -> io::Result<PathBuf> {
     let start = MaybeOwnedFile::borrowed(start);
 

--- a/cap-primitives/src/winx/fs/dir_utils.rs
+++ b/cap-primitives/src/winx/fs/dir_utils.rs
@@ -48,14 +48,17 @@ pub(crate) fn strip_dir_suffix(path: &Path) -> impl Deref<Target = Path> + '_ {
 pub(crate) fn dir_options() -> OpenOptions {
     OpenOptions::new()
         .read(true)
-        .attributes(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .dir_required(true)
+        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
         .clone()
 }
 
-/// Test whether an `OpenOptions` is set to only open directories.
-pub(crate) fn is_dir_options(options: &OpenOptions) -> bool {
-    (options.ext.attributes & Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
-        == Flags::FILE_FLAG_BACKUP_SEMANTICS.bits()
+/// Return an `OpenOptions` for canonicalizing paths.
+pub(crate) fn canonicalize_options() -> OpenOptions {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .clone()
 }
 
 /// Open a directory named by a bare path, using the host process' ambient
@@ -68,6 +71,6 @@ pub(crate) fn is_dir_options(options: &OpenOptions) -> bool {
 pub(crate) unsafe fn open_ambient_dir_impl(path: &Path) -> io::Result<fs::File> {
     fs::OpenOptions::new()
         .read(true)
-        .attributes(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
+        .custom_flags(Flags::FILE_FLAG_BACKUP_SEMANTICS.bits())
         .open(&path)
 }

--- a/cap-primitives/src/winx/fs/mod.rs
+++ b/cap-primitives/src/winx/fs/mod.rs
@@ -14,6 +14,7 @@ mod oflags;
 mod open_options_ext;
 mod open_unchecked;
 mod read_dir_inner;
+mod readlink_impl;
 mod readlink_unchecked;
 mod remove_dir_all_impl;
 mod remove_open_dir_impl;
@@ -31,7 +32,6 @@ pub(crate) use crate::fs::{
     canonicalize_manually_and_follow as canonicalize_impl,
     link_via_parent as link_impl,
     mkdir_via_parent as mkdir_impl,
-    readlink_via_parent as readlink_impl,
     rename_via_parent as rename_impl,
     rmdir_via_parent as rmdir_impl,
     set_permissions_via_parent as set_permissions_impl,
@@ -59,6 +59,7 @@ pub(crate) use mkdir_unchecked::*;
 pub(crate) use open_options_ext::*;
 pub(crate) use open_unchecked::*;
 pub(crate) use read_dir_inner::*;
+pub(crate) use readlink_impl::*;
 pub(crate) use readlink_unchecked::*;
 pub(crate) use remove_dir_all_impl::*;
 pub(crate) use remove_open_dir_impl::*;

--- a/cap-primitives/src/winx/fs/oflags.rs
+++ b/cap-primitives/src/winx/fs/oflags.rs
@@ -31,8 +31,14 @@ pub(in super::super) fn open_options_to_std(opts: &OpenOptions) -> (fs::OpenOpti
         .create_new(opts.create_new)
         .share_mode(opts.ext.share_mode)
         .custom_flags(custom_flags)
-        .attributes(opts.ext.attributes)
-        .security_qos_flags(opts.ext.security_qos_flags);
+        .attributes(opts.ext.attributes);
+
+    // Calling `sequence_qos_flags` with a value of 0 has the side effect
+    // of setting `SECURITY_SQOS_PRESENT`, so don't call it if we don't
+    // have any flags.
+    if opts.ext.security_qos_flags != 0 {
+        std_opts.security_qos_flags(opts.ext.security_qos_flags);
+    }
 
     if let Some(access_mode) = opts.ext.access_mode {
         std_opts.access_mode(access_mode);

--- a/cap-primitives/src/winx/fs/open_options_ext.rs
+++ b/cap-primitives/src/winx/fs/open_options_ext.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "windows_security_qos_flags")]
+use winapi::um::winbase;
+use winapi::um::winnt;
+
 #[derive(Debug, Clone)]
 pub(crate) struct OpenOptionsExt {
     pub(super) access_mode: Option<u32>,
@@ -9,7 +13,6 @@ pub(crate) struct OpenOptionsExt {
 
 impl OpenOptionsExt {
     pub(crate) fn new() -> Self {
-        use winapi::um::winnt;
         Self {
             access_mode: None,
             share_mode: winnt::FILE_SHARE_READ | winnt::FILE_SHARE_WRITE | winnt::FILE_SHARE_DELETE,
@@ -44,7 +47,7 @@ impl std::os::windows::fs::OpenOptionsExt for OpenOptionsExt {
     /// Re-enable this once https://github.com/rust-lang/rust/pull/74074 is in stable.
     #[cfg(feature = "windows_security_qos_flags")]
     fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
-        self.security_qos_flags = flags;
+        self.security_qos_flags = flags | winbase::SECURITY_SQOS_PRESENT;
         self
     }
 

--- a/cap-primitives/src/winx/fs/readlink_impl.rs
+++ b/cap-primitives/src/winx/fs/readlink_impl.rs
@@ -1,0 +1,144 @@
+use crate::fs::{open, FollowSymlinks, OpenOptions};
+use std::{
+    ffi::OsString,
+    fs, io,
+    os::windows::{ffi::OsStringExt, fs::OpenOptionsExt, io::AsRawHandle},
+    path::{Path, PathBuf},
+    ptr, slice,
+};
+
+#[allow(non_snake_case)]
+mod c {
+    use winapi::ctypes::*;
+
+    pub(super) use winapi::{
+        shared::minwindef::*,
+        um::{ioapiset::*, winbase::*, winioctl::*, winnt::*},
+    };
+
+    // Interfaces derived from Rust's
+    // library/std/src/sys/windows/c.rs at revision
+    // f9d17312c9e51e6f9da86db4c6aa7210397ca5f6.
+
+    #[repr(C)]
+    pub(super) struct REPARSE_DATA_BUFFER {
+        pub(super) ReparseTag: c_uint,
+        pub(super) ReparseDataLength: c_ushort,
+        pub(super) Reserved: c_ushort,
+        pub(super) rest: (),
+    }
+
+    #[repr(C)]
+    pub(super) struct SYMBOLIC_LINK_REPARSE_BUFFER {
+        pub(super) SubstituteNameOffset: c_ushort,
+        pub(super) SubstituteNameLength: c_ushort,
+        pub(super) PrintNameOffset: c_ushort,
+        pub(super) PrintNameLength: c_ushort,
+        pub(super) Flags: c_ulong,
+        pub(super) PathBuffer: WCHAR,
+    }
+
+    #[repr(C)]
+    pub struct MOUNT_POINT_REPARSE_BUFFER {
+        pub(super) SubstituteNameOffset: c_ushort,
+        pub(super) SubstituteNameLength: c_ushort,
+        pub(super) PrintNameOffset: c_ushort,
+        pub(super) PrintNameLength: c_ushort,
+        pub(super) PathBuffer: WCHAR,
+    }
+
+    pub(super) const SYMLINK_FLAG_RELATIVE: DWORD = 0x00000001;
+    pub(super) const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
+}
+
+// Implementation derived from Rust's
+// library/std/src/sys/windows/mod.rs at revision
+// f9d17312c9e51e6f9da86db4c6aa7210397ca5f6.
+fn cvt(i: i32) -> io::Result<i32> {
+    if i == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(i)
+    }
+}
+
+// Implementation derived from Rust's
+// library/std/src/sys/windows/fs.rs at revision
+// f9d17312c9e51e6f9da86db4c6aa7210397ca5f6.
+
+/// *Unsandboxed* function similar to `readlink`, but which does not perform sandboxing.
+pub(crate) fn readlink_impl(start: &fs::File, path: &Path) -> io::Result<PathBuf> {
+    // Open the link with no access mode, instead of generic read.
+    // By default FILE_LIST_DIRECTORY is denied for the junction "C:\Documents and Settings", so
+    // this is needed for a common case.
+    let mut opts = OpenOptions::new();
+    opts.access_mode(0);
+    opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT | c::FILE_FLAG_BACKUP_SEMANTICS);
+    opts.follow(FollowSymlinks::No);
+    let file = open(start, path, &opts)?;
+    readlink(&file)
+}
+
+fn reparse_point<'a>(
+    file: &fs::File,
+    space: &'a mut [u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE],
+) -> io::Result<(c::DWORD, &'a c::REPARSE_DATA_BUFFER)> {
+    unsafe {
+        let mut bytes = 0;
+        cvt({
+            c::DeviceIoControl(
+                file.as_raw_handle(),
+                c::FSCTL_GET_REPARSE_POINT,
+                ptr::null_mut(),
+                0,
+                space.as_mut_ptr() as *mut _,
+                space.len() as c::DWORD,
+                &mut bytes,
+                ptr::null_mut(),
+            )
+        })?;
+        Ok((bytes, &*(space.as_ptr() as *const c::REPARSE_DATA_BUFFER)))
+    }
+}
+
+fn readlink(file: &fs::File) -> io::Result<PathBuf> {
+    let mut space = [0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    let (_bytes, buf) = reparse_point(file, &mut space)?;
+    unsafe {
+        let (path_buffer, subst_off, subst_len, relative) = match buf.ReparseTag {
+            c::IO_REPARSE_TAG_SYMLINK => {
+                let info: *const c::SYMBOLIC_LINK_REPARSE_BUFFER =
+                    &buf.rest as *const _ as *const _;
+                (
+                    &(*info).PathBuffer as *const _ as *const u16,
+                    (*info).SubstituteNameOffset / 2,
+                    (*info).SubstituteNameLength / 2,
+                    (*info).Flags & c::SYMLINK_FLAG_RELATIVE != 0,
+                )
+            }
+            c::IO_REPARSE_TAG_MOUNT_POINT => {
+                let info: *const c::MOUNT_POINT_REPARSE_BUFFER = &buf.rest as *const _ as *const _;
+                (
+                    &(*info).PathBuffer as *const _ as *const u16,
+                    (*info).SubstituteNameOffset / 2,
+                    (*info).SubstituteNameLength / 2,
+                    false,
+                )
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Unsupported reparse point type",
+                ));
+            }
+        };
+        let subst_ptr = path_buffer.offset(subst_off as isize);
+        let mut subst = slice::from_raw_parts(subst_ptr, subst_len as usize);
+        // Absolute paths start with an NT internal namespace prefix `\??\`
+        // We should not let it leak through.
+        if !relative && subst.starts_with(&[92u16, 63u16, 63u16, 92u16]) {
+            subst = &subst[4..];
+        }
+        Ok(PathBuf::from(OsString::from_wide(subst)))
+    }
+}

--- a/cap-primitives/src/yanix/fs/dir_utils.rs
+++ b/cap-primitives/src/yanix/fs/dir_utils.rs
@@ -45,15 +45,12 @@ pub(crate) fn strip_dir_suffix(path: &Path) -> impl Deref<Target = Path> + '_ {
 
 /// Return an `OpenOptions` for opening directories.
 pub(crate) fn dir_options() -> OpenOptions {
-    OpenOptions::new()
-        .read(true)
-        .custom_flags(OFlags::DIRECTORY.bits())
-        .clone()
+    OpenOptions::new().read(true).dir_required(true).clone()
 }
 
-/// Test whether an `OpenOptions` is set to only open directories.
-pub(crate) fn is_dir_options(options: &OpenOptions) -> bool {
-    (options.ext.custom_flags & OFlags::DIRECTORY.bits()) == OFlags::DIRECTORY.bits()
+/// Return an `OpenOptions` for canonicalizing paths.
+pub(crate) fn canonicalize_options() -> OpenOptions {
+    OpenOptions::new().read(true).clone()
 }
 
 /// Open a directory named by a bare path, using the host process' ambient

--- a/cap-primitives/src/yanix/fs/oflags.rs
+++ b/cap-primitives/src/yanix/fs/oflags.rs
@@ -28,6 +28,9 @@ pub(in super::super) fn compute_oflags(options: &OpenOptions) -> io::Result<OFla
     if options.follow == FollowSymlinks::No {
         oflags |= OFlags::NOFOLLOW;
     }
+    if options.dir_required {
+        oflags |= OFlags::DIRECTORY;
+    }
     oflags |=
         OFlags::from_bits(options.ext.custom_flags).expect("unrecognized OFlags") & !accmode();
     Ok(oflags)

--- a/cap-primitives/src/yanix/fs/open_unchecked.rs
+++ b/cap-primitives/src/yanix/fs/open_unchecked.rs
@@ -1,7 +1,7 @@
 use super::compute_oflags;
 #[cfg(target_os = "linux")]
 use crate::fs::ensure_cloexec;
-use crate::fs::{is_dir_options, stat_unchecked, OpenOptions, OpenUncheckedError};
+use crate::fs::{stat_unchecked, OpenOptions, OpenUncheckedError};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::{fs, path::Path};
@@ -45,7 +45,7 @@ pub(crate) fn open_unchecked(
 
         Some(libc::ENOENT) => Err(OpenUncheckedError::NotFound(err)),
         Some(libc::ENOTDIR) => {
-            if is_dir_options(options)
+            if options.dir_required
                 && stat_unchecked(start, path, options.follow)
                     .map(|m| m.file_type().is_symlink())
                     .unwrap_or(false)

--- a/cap-std/README.md
+++ b/cap-std/README.md
@@ -15,10 +15,8 @@
 This crate provides a capability-oriented version of [`std`]. See the
 [toplevel README.md] for more information about capability-oriented security.
 
-The filesystem module, [`cap_std::fs`], is known to compile on Linux, macOS, and
-FreeBSD, and probably can be easily ported to other modern Unix-family platforms.
-Windows support is in development; basic functionality works, but not all features
-are implemented yet. WASI support is in development, though not yet usable.
+The filesystem module, [`cap_std::fs`], currently supports Linux, macOS,
+FreeBSD, and Windows. WASI support is in development, though not yet usable.
 
 The networking module, `net`, is not yet usable.
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -840,7 +840,6 @@ fn symlink_noexist() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn read_link() {
     if cfg!(windows) {
         // directory symlink
@@ -1232,7 +1231,6 @@ fn canonicalize_works_simple() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)] // TODO investigate why this one is failing
 fn realpath_works() {
     let tmpdir = tmpdir();
     if !got_symlink_permission(&tmpdir) {


### PR DESCRIPTION
 - Use `FILE_FLAG_BACKUP_SEMANTICS` when opening a path for
   canonicalization.
 - `FILE_FLAG_BACKUP_SEMANTICS` is a custom flag rather than an
   attribute.
 - Allow `open_manually` to support custom flags in combination with
   paths with trailing slashes.
 - Fix windows' `open_unchecked` to support opening files with
   `FILE_FLAG_OPEN_REPARSE_POINT` without returning an error.
 - Port the windows `readlink` implementation from Rust's `std`,
   replacing `readlink_via_parent`, which avoids the conflict of
   `open_parent`'s use of `.` with Windows' use of directory
   symlinks with no other accessibility.