### PR TITLE
Enable windows_security_qos_flags by default.

### DIFF
--- a/cap-primitives/Cargo.toml
+++ b/cap-primitives/Cargo.toml
@@ -45,12 +45,12 @@ winapi = { version = "0.3.9", features = [
 ] }
 
 [features]
-default = ["no_racy_asserts"]
+default = ["no_racy_asserts", "windows_security_qos_flags"]
 no_racy_asserts = []
-nightly = ["windows_by_handle", "windows_file_type_ext", "windows_security_qos_flags"]
+nightly = ["windows_by_handle", "windows_file_type_ext"]
 windows_by_handle = [] # https://github.com/rust-lang/rust/issues/63010
 windows_file_type_ext = []
-windows_security_qos_flags = [] # https://github.com/rust-lang/rust/issues/65439
+windows_security_qos_flags = [] # https://github.com/rust-lang/rust/pull/74074
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
It appears the fix for `security_qos_flags`'s return type is now stable
in Rust 1.46.0.